### PR TITLE
Fix "and" / "or" being highlighted inside other words

### DIFF
--- a/syntaxes/vehicle.tmLanguage.yml
+++ b/syntaxes/vehicle.tmLanguage.yml
@@ -19,13 +19,24 @@ repository:
   declaration_keywords:
     match: >-
       (?x)
-        ^
         (?:
-          (type)
+          ^
+          (?:
+            (type)
+            |(record)
+          )
+        )
+        |(?:
+          \b
+          (?:
+            (where)
+          )
         )
         \b
     captures:
       "1": { name: keyword.other.declaration.type.vehicle }
+      "2": { name: keyword.other.declaration.record.vehicle }
+      "3": { name: keyword.other.declaration.where.vehicle }
 
   annotation_keywords:
     match: >-

--- a/syntaxes/vehicle.tmLanguage.yml
+++ b/syntaxes/vehicle.tmLanguage.yml
@@ -30,6 +30,7 @@ repository:
           \b
           (?:
             (where)
+            |(supports)
           )
         )
         \b
@@ -37,6 +38,7 @@ repository:
       "1": { name: keyword.other.declaration.type.vehicle }
       "2": { name: keyword.other.declaration.record.vehicle }
       "3": { name: keyword.other.declaration.where.vehicle }
+      "4": { name: keyword.other.declaration.supports.vehicle }
 
   annotation_keywords:
     match: >-

--- a/syntaxes/vehicle.tmLanguage.yml
+++ b/syntaxes/vehicle.tmLanguage.yml
@@ -166,8 +166,8 @@ repository:
           |(::)
           |(!)
           |(=)
-          |(and)
-          |(or)
+          |(\band\b)
+          |(\bor\b)
         )
         (?![\p{S}\p{P}])
     captures:

--- a/syntaxes/vehicle.tmLanguage.yml
+++ b/syntaxes/vehicle.tmLanguage.yml
@@ -36,8 +36,11 @@ repository:
           |(@dataset)
           |(@parameter)
           |(@property)
-          |(@postulate)
+          |(@builtin)
           |(@noinline)
+          |(@tensor)
+          |(@typeclass)
+          |(@instance)
         )
         \b
     captures:
@@ -47,6 +50,9 @@ repository:
       "4": { name: keyword.other.declaration.property.vehicle }
       "5": { name: keyword.other.declaration.postulate.vehicle }
       "6": { name: keyword.other.declaration.noinline.vehicle }
+      "7": { name: keyword.other.declaration.tensor.vehicle }
+      "8": { name: keyword.other.declaration.typeclass.vehicle }
+      "9": { name: keyword.other.declaration.instance.vehicle }
 
   control_keywords:
     match: >-

--- a/tests/simple.test.vcl
+++ b/tests/simple.test.vcl
@@ -2,11 +2,11 @@
 
 @network
 -- <-------- keyword.other.declaration.network.vehicle
-controller : InputVector -> Tensor Rat [1]
+controller : InputVector -> Tensor Real [1]
 --         ^ keyword.operator.colon.vehicle
 --                       ^^ keyword.operator.arrow.vehicle
 --                          ^^^^^^ support.type.tensor.vehicle
---                                 ^^^ support.type.rat.vehicle
+--                                 ^^^^ support.type.rat.vehicle
 
 @dataset
 -- <-------- keyword.other.declaration.dataset.vehicle
@@ -30,7 +30,7 @@ trainingLabels : Tensor Label [m]
 m : Nat
 --  ^^^ support.type.nat.vehicle
 
-type InputVector = Vector Rat 5
+type InputVector = Vector Real 5
 --               ^ keyword.operator.define.vehicle
 -- <---- keyword.other.declaration.type.vehicle
 --                 ^^^^^^ support.type.vector.vehicle

--- a/tests/snap/acasXu.vcl
+++ b/tests/snap/acasXu.vcl
@@ -18,7 +18,7 @@ pi = 3.141592
 -- We first define a new name for the type of inputs of the network.
 -- In particular, it takes inputs of the form of a vector of 5 rational numbers.
 
-type InputVector = Vector Rat 5
+type InputVector = Vector Real 5
 
 -- Next we add meaningful names for the indices.
 -- The fact that all vector types come annotated with their size means that it
@@ -38,7 +38,7 @@ intruderSpeed      = 4   -- measured in meters/second
 -- Outputs are also a vector of 5 rationals. Each one representing the score
 -- for the 5 available courses of action.
 
-type OutputVector = Vector Rat 5
+type OutputVector = Vector Real 5
 
 -- Again we define meaningful names for the indices into output vectors.
 
@@ -71,7 +71,7 @@ acasXu : InputVector -> OutputVector
 
 -- For clarity, we therefore define a new type synonym
 -- for unnormalised input vectors which are in the problem space.
-type UnnormalisedInputVector = Vector Rat 5
+type UnnormalisedInputVector = Vector Real 5
 
 -- Next we define the minimum and maximum values that each input can take.
 -- These correspond to the range of the inputs that the network is designed

--- a/tests/snap/acasXu.vcl.snap
+++ b/tests/snap/acasXu.vcl.snap
@@ -48,9 +48,7 @@
 >
 >type InputVector = Vector Real 5
 #^^^^ source.vehicle keyword.other.declaration.type.vehicle
-#    ^^^^^^^^^^ source.vehicle
-#              ^^ source.vehicle keyword.operator.or.vehicle
-#                ^ source.vehicle
+#    ^^^^^^^^^^^^^ source.vehicle
 #                 ^ source.vehicle keyword.operator.define.vehicle
 #                  ^ source.vehicle
 #                   ^^^^^^ source.vehicle support.type.vector.vehicle
@@ -132,9 +130,7 @@
 >
 >type OutputVector = Vector Real 5
 #^^^^ source.vehicle keyword.other.declaration.type.vehicle
-#    ^^^^^^^^^^^ source.vehicle
-#               ^^ source.vehicle keyword.operator.or.vehicle
-#                 ^ source.vehicle
+#    ^^^^^^^^^^^^^^ source.vehicle
 #                  ^ source.vehicle keyword.operator.define.vehicle
 #                   ^ source.vehicle
 #                    ^^^^^^ source.vehicle support.type.vector.vehicle
@@ -195,12 +191,9 @@
 >acasXu : InputVector -> OutputVector
 #^^^^^^^ source.vehicle
 #       ^ source.vehicle keyword.operator.colon.vehicle
-#        ^^^^^^^^^^ source.vehicle
-#                  ^^ source.vehicle keyword.operator.or.vehicle
-#                    ^ source.vehicle
+#        ^^^^^^^^^^^^^ source.vehicle
 #                     ^^ source.vehicle keyword.operator.arrow.vehicle
-#                       ^^^^^^^^^^^ source.vehicle
-#                                  ^^ source.vehicle keyword.operator.or.vehicle
+#                       ^^^^^^^^^^^^^^ source.vehicle
 >
 >--------------------------------------------------------------------------------
 #^^ source.vehicle comment.line.double-dash.vehicle punctuation.definition.comment.vehicle
@@ -239,11 +232,7 @@
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.vehicle comment.line.double-dash.vehicle
 >type UnnormalisedInputVector = Vector Real 5
 #^^^^ source.vehicle keyword.other.declaration.type.vehicle
-#    ^^^^ source.vehicle
-#        ^^ source.vehicle keyword.operator.or.vehicle
-#          ^^^^^^^^^^^^^^^^ source.vehicle
-#                          ^^ source.vehicle keyword.operator.or.vehicle
-#                            ^ source.vehicle
+#    ^^^^^^^^^^^^^^^^^^^^^^^^^ source.vehicle
 #                             ^ source.vehicle keyword.operator.define.vehicle
 #                              ^ source.vehicle
 #                               ^^^^^^ source.vehicle support.type.vector.vehicle
@@ -264,10 +253,7 @@
 >minimumInputValues : UnnormalisedInputVector
 #^^^^^^^^^^^^^^^^^^^ source.vehicle
 #                   ^ source.vehicle keyword.operator.colon.vehicle
-#                    ^^^^ source.vehicle
-#                        ^^ source.vehicle keyword.operator.or.vehicle
-#                          ^^^^^^^^^^^^^^^^ source.vehicle
-#                                          ^^ source.vehicle keyword.operator.or.vehicle
+#                    ^^^^^^^^^^^^^^^^^^^^^^^^^ source.vehicle
 >minimumInputValues = [0,0,0,0,0]
 #^^^^^^^^^^^^^^^^^^^ source.vehicle
 #                   ^ source.vehicle keyword.operator.define.vehicle
@@ -286,10 +272,7 @@
 >maximumInputValues : UnnormalisedInputVector
 #^^^^^^^^^^^^^^^^^^^ source.vehicle
 #                   ^ source.vehicle keyword.operator.colon.vehicle
-#                    ^^^^ source.vehicle
-#                        ^^ source.vehicle keyword.operator.or.vehicle
-#                          ^^^^^^^^^^^^^^^^ source.vehicle
-#                                          ^^ source.vehicle keyword.operator.or.vehicle
+#                    ^^^^^^^^^^^^^^^^^^^^^^^^^ source.vehicle
 >maximumInputValues = [60261.0, 2*pi, 2*pi, 1100.0, 1200.0]
 #^^^^^^^^^^^^^^^^^^^ source.vehicle
 #                   ^ source.vehicle keyword.operator.define.vehicle
@@ -316,11 +299,7 @@
 >validInput : UnnormalisedInputVector -> Bool
 #^^^^^^^^^^^ source.vehicle
 #           ^ source.vehicle keyword.operator.colon.vehicle
-#            ^^^^ source.vehicle
-#                ^^ source.vehicle keyword.operator.or.vehicle
-#                  ^^^^^^^^^^^^^^^^ source.vehicle
-#                                  ^^ source.vehicle keyword.operator.or.vehicle
-#                                    ^ source.vehicle
+#            ^^^^^^^^^^^^^^^^^^^^^^^^^ source.vehicle
 #                                     ^^ source.vehicle keyword.operator.arrow.vehicle
 #                                       ^ source.vehicle
 #                                        ^^^^ source.vehicle support.type.bool.vehicle
@@ -349,10 +328,7 @@
 >meanScalingValues : UnnormalisedInputVector
 #^^^^^^^^^^^^^^^^^^ source.vehicle
 #                  ^ source.vehicle keyword.operator.colon.vehicle
-#                   ^^^^ source.vehicle
-#                       ^^ source.vehicle keyword.operator.or.vehicle
-#                         ^^^^^^^^^^^^^^^^ source.vehicle
-#                                         ^^ source.vehicle keyword.operator.or.vehicle
+#                   ^^^^^^^^^^^^^^^^^^^^^^^^^ source.vehicle
 >meanScalingValues = [19791.091, 0.0, 0.0, 650.0, 600.0]
 #^^^^^^^^^^^^^^^^^^ source.vehicle
 #                  ^ source.vehicle keyword.operator.define.vehicle
@@ -375,22 +351,13 @@
 #^^ source.vehicle comment.line.double-dash.vehicle punctuation.definition.comment.vehicle
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.vehicle comment.line.double-dash.vehicle
 >normalise : UnnormalisedInputVector -> InputVector
-#^ source.vehicle
-# ^^ source.vehicle keyword.operator.or.vehicle
-#   ^^^^^^^ source.vehicle
+#^^^^^^^^^^ source.vehicle
 #          ^ source.vehicle keyword.operator.colon.vehicle
-#           ^^^^ source.vehicle
-#               ^^ source.vehicle keyword.operator.or.vehicle
-#                 ^^^^^^^^^^^^^^^^ source.vehicle
-#                                 ^^ source.vehicle keyword.operator.or.vehicle
-#                                   ^ source.vehicle
+#           ^^^^^^^^^^^^^^^^^^^^^^^^^ source.vehicle
 #                                    ^^ source.vehicle keyword.operator.arrow.vehicle
-#                                      ^^^^^^^^^^ source.vehicle
-#                                                ^^ source.vehicle keyword.operator.or.vehicle
+#                                      ^^^^^^^^^^^^^ source.vehicle
 >normalise x = foreach i .
-#^ source.vehicle
-# ^^ source.vehicle keyword.operator.or.vehicle
-#   ^^^^^^^^^ source.vehicle
+#^^^^^^^^^^^^ source.vehicle
 #            ^ source.vehicle keyword.operator.define.vehicle
 #             ^ source.vehicle
 #              ^^^^^^^ source.vehicle keyword.control.foreach.vehicle
@@ -416,26 +383,15 @@
 #^^ source.vehicle comment.line.double-dash.vehicle punctuation.definition.comment.vehicle
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.vehicle comment.line.double-dash.vehicle
 >normAcasXu : UnnormalisedInputVector -> OutputVector
-#^ source.vehicle
-# ^^ source.vehicle keyword.operator.or.vehicle
-#   ^^^^^^^^ source.vehicle
+#^^^^^^^^^^^ source.vehicle
 #           ^ source.vehicle keyword.operator.colon.vehicle
-#            ^^^^ source.vehicle
-#                ^^ source.vehicle keyword.operator.or.vehicle
-#                  ^^^^^^^^^^^^^^^^ source.vehicle
-#                                  ^^ source.vehicle keyword.operator.or.vehicle
-#                                    ^ source.vehicle
+#            ^^^^^^^^^^^^^^^^^^^^^^^^^ source.vehicle
 #                                     ^^ source.vehicle keyword.operator.arrow.vehicle
-#                                       ^^^^^^^^^^^ source.vehicle
-#                                                  ^^ source.vehicle keyword.operator.or.vehicle
+#                                       ^^^^^^^^^^^^^^ source.vehicle
 >normAcasXu x = acasXu (normalise x)
-#^ source.vehicle
-# ^^ source.vehicle keyword.operator.or.vehicle
-#   ^^^^^^^^^^ source.vehicle
+#^^^^^^^^^^^^^ source.vehicle
 #             ^ source.vehicle keyword.operator.define.vehicle
-#              ^^^^^^^^^^ source.vehicle
-#                        ^^ source.vehicle keyword.operator.or.vehicle
-#                          ^^^^^^^^^^ source.vehicle
+#              ^^^^^^^^^^^^^^^^^^^^^^ source.vehicle
 >
 >-- A constraint that says the network chooses output `i` when given the
 #^^ source.vehicle comment.line.double-dash.vehicle punctuation.definition.comment.vehicle
@@ -455,11 +411,7 @@
 #                ^ source.vehicle constant.numeric.integral.decimal.vehicle
 #                 ^ source.vehicle
 #                  ^^ source.vehicle keyword.operator.arrow.vehicle
-#                    ^^^^ source.vehicle
-#                        ^^ source.vehicle keyword.operator.or.vehicle
-#                          ^^^^^^^^^^^^^^^^ source.vehicle
-#                                          ^^ source.vehicle keyword.operator.or.vehicle
-#                                            ^ source.vehicle
+#                    ^^^^^^^^^^^^^^^^^^^^^^^^^ source.vehicle
 #                                             ^^ source.vehicle keyword.operator.arrow.vehicle
 #                                               ^ source.vehicle
 #                                                ^^^^ source.vehicle support.type.bool.vehicle
@@ -474,15 +426,11 @@
 #                           ^^ source.vehicle keyword.operator.distinct.vehicle
 #                             ^^^ source.vehicle
 #                                ^^ source.vehicle keyword.operator.implies.vehicle
-#                                  ^^ source.vehicle
-#                                    ^^ source.vehicle keyword.operator.or.vehicle
-#                                      ^^^^^^^^^^ source.vehicle
+#                                  ^^^^^^^^^^^^^^ source.vehicle
 #                                                ^ source.vehicle keyword.operator.lookup.vehicle
 #                                                 ^^^ source.vehicle
 #                                                    ^ source.vehicle keyword.operator.lt.vehicle
-#                                                     ^^ source.vehicle
-#                                                       ^^ source.vehicle keyword.operator.or.vehicle
-#                                                         ^^^^^^^^^^ source.vehicle
+#                                                     ^^^^^^^^^^^^^^ source.vehicle
 #                                                                   ^ source.vehicle keyword.operator.lookup.vehicle
 #                                                                    ^^^ source.vehicle
 >
@@ -510,11 +458,7 @@
 >intruderDistantAndSlower : UnnormalisedInputVector -> Bool
 #^^^^^^^^^^^^^^^^^^^^^^^^^ source.vehicle
 #                         ^ source.vehicle keyword.operator.colon.vehicle
-#                          ^^^^ source.vehicle
-#                              ^^ source.vehicle keyword.operator.or.vehicle
-#                                ^^^^^^^^^^^^^^^^ source.vehicle
-#                                                ^^ source.vehicle keyword.operator.or.vehicle
-#                                                  ^ source.vehicle
+#                          ^^^^^^^^^^^^^^^^^^^^^^^^^ source.vehicle
 #                                                   ^^ source.vehicle keyword.operator.arrow.vehicle
 #                                                     ^ source.vehicle
 #                                                      ^^^^ source.vehicle support.type.bool.vehicle
@@ -566,9 +510,7 @@
 #                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.vehicle
 #                                                                   ^^ source.vehicle keyword.operator.implies.vehicle
 >  normAcasXu x ! clearOfConflict <= 1500
-#^^^ source.vehicle
-#   ^^ source.vehicle keyword.operator.or.vehicle
-#     ^^^^^^^^^^ source.vehicle
+#^^^^^^^^^^^^^^^ source.vehicle
 #               ^ source.vehicle keyword.operator.lookup.vehicle
 #                ^^^^^^^^^^^^^^^^^ source.vehicle
 #                                 ^^ source.vehicle keyword.operator.lte.vehicle
@@ -616,15 +558,11 @@
 #   ^^^^^^ source.vehicle keyword.control.exists.vehicle
 #         ^^^ source.vehicle
 #            ^ source.vehicle keyword.operator.dot.vehicle
-#             ^^^ source.vehicle
-#                ^^ source.vehicle keyword.operator.or.vehicle
-#                  ^^^^^^^^^^ source.vehicle
+#             ^^^^^^^^^^^^^^^ source.vehicle
 #                            ^ source.vehicle keyword.operator.lookup.vehicle
 #                             ^^^^ source.vehicle
 #                                 ^ source.vehicle keyword.operator.gt.vehicle
-#                                  ^^^ source.vehicle
-#                                     ^^ source.vehicle keyword.operator.or.vehicle
-#                                       ^^^^^^^^^^ source.vehicle
+#                                  ^^^^^^^^^^^^^^^ source.vehicle
 #                                                 ^ source.vehicle keyword.operator.lookup.vehicle
 #                                                  ^^^^^^^^^^^^^^^^^^^ source.vehicle
 >
@@ -649,11 +587,7 @@
 >directlyAhead : UnnormalisedInputVector -> Bool
 #^^^^^^^^^^^^^^ source.vehicle
 #              ^ source.vehicle keyword.operator.colon.vehicle
-#               ^^^^ source.vehicle
-#                   ^^ source.vehicle keyword.operator.or.vehicle
-#                     ^^^^^^^^^^^^^^^^ source.vehicle
-#                                     ^^ source.vehicle keyword.operator.or.vehicle
-#                                       ^ source.vehicle
+#               ^^^^^^^^^^^^^^^^^^^^^^^^^ source.vehicle
 #                                        ^^ source.vehicle keyword.operator.arrow.vehicle
 #                                          ^ source.vehicle
 #                                           ^^^^ source.vehicle support.type.bool.vehicle
@@ -689,11 +623,7 @@
 >movingTowards : UnnormalisedInputVector -> Bool
 #^^^^^^^^^^^^^^ source.vehicle
 #              ^ source.vehicle keyword.operator.colon.vehicle
-#               ^^^^ source.vehicle
-#                   ^^ source.vehicle keyword.operator.or.vehicle
-#                     ^^^^^^^^^^^^^^^^ source.vehicle
-#                                     ^^ source.vehicle keyword.operator.or.vehicle
-#                                       ^ source.vehicle
+#               ^^^^^^^^^^^^^^^^^^^^^^^^^ source.vehicle
 #                                        ^^ source.vehicle keyword.operator.arrow.vehicle
 #                                          ^ source.vehicle
 #                                           ^^^^ source.vehicle support.type.bool.vehicle
@@ -775,11 +705,7 @@
 >movingAway : UnnormalisedInputVector -> Bool
 #^^^^^^^^^^^ source.vehicle
 #           ^ source.vehicle keyword.operator.colon.vehicle
-#            ^^^^ source.vehicle
-#                ^^ source.vehicle keyword.operator.or.vehicle
-#                  ^^^^^^^^^^^^^^^^ source.vehicle
-#                                  ^^ source.vehicle keyword.operator.or.vehicle
-#                                    ^ source.vehicle
+#            ^^^^^^^^^^^^^^^^^^^^^^^^^ source.vehicle
 #                                     ^^ source.vehicle keyword.operator.arrow.vehicle
 #                                       ^ source.vehicle
 #                                        ^^^^ source.vehicle support.type.bool.vehicle
@@ -862,11 +788,7 @@
 >nearAndApproachingFromLeft : UnnormalisedInputVector -> Bool
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.vehicle
 #                           ^ source.vehicle keyword.operator.colon.vehicle
-#                            ^^^^ source.vehicle
-#                                ^^ source.vehicle keyword.operator.or.vehicle
-#                                  ^^^^^^^^^^^^^^^^ source.vehicle
-#                                                  ^^ source.vehicle keyword.operator.or.vehicle
-#                                                    ^ source.vehicle
+#                            ^^^^^^^^^^^^^^^^^^^^^^^^^ source.vehicle
 #                                                     ^^ source.vehicle keyword.operator.arrow.vehicle
 #                                                       ^ source.vehicle
 #                                                        ^^^^ source.vehicle support.type.bool.vehicle
@@ -979,11 +901,7 @@
 >intruderFarAway : UnnormalisedInputVector -> Bool
 #^^^^^^^^^^^^^^^^ source.vehicle
 #                ^ source.vehicle keyword.operator.colon.vehicle
-#                 ^^^^ source.vehicle
-#                     ^^ source.vehicle keyword.operator.or.vehicle
-#                       ^^^^^^^^^^^^^^^^ source.vehicle
-#                                       ^^ source.vehicle keyword.operator.or.vehicle
-#                                         ^ source.vehicle
+#                 ^^^^^^^^^^^^^^^^^^^^^^^^^ source.vehicle
 #                                          ^^ source.vehicle keyword.operator.arrow.vehicle
 #                                            ^ source.vehicle
 #                                             ^^^^ source.vehicle support.type.bool.vehicle
@@ -1105,11 +1023,7 @@
 >largeVerticalSeparation : UnnormalisedInputVector -> Bool
 #^^^^^^^^^^^^^^^^^^^^^^^^ source.vehicle
 #                        ^ source.vehicle keyword.operator.colon.vehicle
-#                         ^^^^ source.vehicle
-#                             ^^ source.vehicle keyword.operator.or.vehicle
-#                               ^^^^^^^^^^^^^^^^ source.vehicle
-#                                               ^^ source.vehicle keyword.operator.or.vehicle
-#                                                 ^ source.vehicle
+#                         ^^^^^^^^^^^^^^^^^^^^^^^^^ source.vehicle
 #                                                  ^^ source.vehicle keyword.operator.arrow.vehicle
 #                                                    ^ source.vehicle
 #                                                     ^^^^ source.vehicle support.type.bool.vehicle
@@ -1224,11 +1138,7 @@
 >largeVerticalSeparationAndPreviousWeakLeft : UnnormalisedInputVector -> Bool
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.vehicle
 #                                           ^ source.vehicle keyword.operator.colon.vehicle
-#                                            ^^^^ source.vehicle
-#                                                ^^ source.vehicle keyword.operator.or.vehicle
-#                                                  ^^^^^^^^^^^^^^^^ source.vehicle
-#                                                                  ^^ source.vehicle keyword.operator.or.vehicle
-#                                                                    ^ source.vehicle
+#                                            ^^^^^^^^^^^^^^^^^^^^^^^^^ source.vehicle
 #                                                                     ^^ source.vehicle keyword.operator.arrow.vehicle
 #                                                                       ^ source.vehicle
 #                                                                        ^^^^ source.vehicle support.type.bool.vehicle
@@ -1346,11 +1256,7 @@
 >previousWeakRightAndNearbyIntruder : UnnormalisedInputVector -> Bool
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.vehicle
 #                                   ^ source.vehicle keyword.operator.colon.vehicle
-#                                    ^^^^ source.vehicle
-#                                        ^^ source.vehicle keyword.operator.or.vehicle
-#                                          ^^^^^^^^^^^^^^^^ source.vehicle
-#                                                          ^^ source.vehicle keyword.operator.or.vehicle
-#                                                            ^ source.vehicle
+#                                    ^^^^^^^^^^^^^^^^^^^^^^^^^ source.vehicle
 #                                                             ^^ source.vehicle keyword.operator.arrow.vehicle
 #                                                               ^ source.vehicle
 #                                                                ^^^^ source.vehicle support.type.bool.vehicle
@@ -1466,11 +1372,7 @@
 >intruderFarAway2 : UnnormalisedInputVector -> Bool
 #^^^^^^^^^^^^^^^^^ source.vehicle
 #                 ^ source.vehicle keyword.operator.colon.vehicle
-#                  ^^^^ source.vehicle
-#                      ^^ source.vehicle keyword.operator.or.vehicle
-#                        ^^^^^^^^^^^^^^^^ source.vehicle
-#                                        ^^ source.vehicle keyword.operator.or.vehicle
-#                                          ^ source.vehicle
+#                  ^^^^^^^^^^^^^^^^^^^^^^^^^ source.vehicle
 #                                           ^^ source.vehicle keyword.operator.arrow.vehicle
 #                                             ^ source.vehicle
 #                                              ^^^^ source.vehicle support.type.bool.vehicle

--- a/tests/snap/acasXu.vcl.snap
+++ b/tests/snap/acasXu.vcl.snap
@@ -46,7 +46,7 @@
 #^^ source.vehicle comment.line.double-dash.vehicle punctuation.definition.comment.vehicle
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.vehicle comment.line.double-dash.vehicle
 >
->type InputVector = Vector Rat 5
+>type InputVector = Vector Real 5
 #^^^^ source.vehicle keyword.other.declaration.type.vehicle
 #    ^^^^^^^^^^ source.vehicle
 #              ^^ source.vehicle keyword.operator.or.vehicle
@@ -55,9 +55,9 @@
 #                  ^ source.vehicle
 #                   ^^^^^^ source.vehicle support.type.vector.vehicle
 #                         ^ source.vehicle
-#                          ^^^ source.vehicle support.type.rat.vehicle
-#                             ^ source.vehicle
-#                              ^ source.vehicle constant.numeric.integral.decimal.vehicle
+#                          ^^^^ source.vehicle support.type.rat.vehicle
+#                              ^ source.vehicle
+#                               ^ source.vehicle constant.numeric.integral.decimal.vehicle
 >
 >-- Next we add meaningful names for the indices.
 #^^ source.vehicle comment.line.double-dash.vehicle punctuation.definition.comment.vehicle
@@ -130,7 +130,7 @@
 #^^ source.vehicle comment.line.double-dash.vehicle punctuation.definition.comment.vehicle
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.vehicle comment.line.double-dash.vehicle
 >
->type OutputVector = Vector Rat 5
+>type OutputVector = Vector Real 5
 #^^^^ source.vehicle keyword.other.declaration.type.vehicle
 #    ^^^^^^^^^^^ source.vehicle
 #               ^^ source.vehicle keyword.operator.or.vehicle
@@ -139,9 +139,9 @@
 #                   ^ source.vehicle
 #                    ^^^^^^ source.vehicle support.type.vector.vehicle
 #                          ^ source.vehicle
-#                           ^^^ source.vehicle support.type.rat.vehicle
-#                              ^ source.vehicle
-#                               ^ source.vehicle constant.numeric.integral.decimal.vehicle
+#                           ^^^^ source.vehicle support.type.rat.vehicle
+#                               ^ source.vehicle
+#                                ^ source.vehicle constant.numeric.integral.decimal.vehicle
 >
 >-- Again we define meaningful names for the indices into output vectors.
 #^^ source.vehicle comment.line.double-dash.vehicle punctuation.definition.comment.vehicle
@@ -237,7 +237,7 @@
 >-- for unnormalised input vectors which are in the problem space.
 #^^ source.vehicle comment.line.double-dash.vehicle punctuation.definition.comment.vehicle
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.vehicle comment.line.double-dash.vehicle
->type UnnormalisedInputVector = Vector Rat 5
+>type UnnormalisedInputVector = Vector Real 5
 #^^^^ source.vehicle keyword.other.declaration.type.vehicle
 #    ^^^^ source.vehicle
 #        ^^ source.vehicle keyword.operator.or.vehicle
@@ -248,9 +248,9 @@
 #                              ^ source.vehicle
 #                               ^^^^^^ source.vehicle support.type.vector.vehicle
 #                                     ^ source.vehicle
-#                                      ^^^ source.vehicle support.type.rat.vehicle
-#                                         ^ source.vehicle
-#                                          ^ source.vehicle constant.numeric.integral.decimal.vehicle
+#                                      ^^^^ source.vehicle support.type.rat.vehicle
+#                                          ^ source.vehicle
+#                                           ^ source.vehicle constant.numeric.integral.decimal.vehicle
 >
 >-- Next we define the minimum and maximum values that each input can take.
 #^^ source.vehicle comment.line.double-dash.vehicle punctuation.definition.comment.vehicle

--- a/tests/snap/alternating.vcl
+++ b/tests/snap/alternating.vcl
@@ -1,5 +1,5 @@
 @network
-f : Tensor Rat [1] -> Tensor Rat [1]
+f : Tensor Real [1] -> Tensor Real [1]
 
 @property
 p : Bool

--- a/tests/snap/alternating.vcl.snap
+++ b/tests/snap/alternating.vcl.snap
@@ -1,23 +1,23 @@
 >@network
 #^^^^^^^^ source.vehicle keyword.other.declaration.network.vehicle
->f : Tensor Rat [1] -> Tensor Rat [1]
+>f : Tensor Real [1] -> Tensor Real [1]
 #^^ source.vehicle
 #  ^ source.vehicle keyword.operator.colon.vehicle
 #   ^ source.vehicle
 #    ^^^^^^ source.vehicle support.type.tensor.vehicle
 #          ^ source.vehicle
-#           ^^^ source.vehicle support.type.rat.vehicle
-#              ^^ source.vehicle
-#                ^ source.vehicle constant.numeric.integral.decimal.vehicle
-#                 ^^ source.vehicle
-#                   ^^ source.vehicle keyword.operator.arrow.vehicle
-#                     ^ source.vehicle
-#                      ^^^^^^ source.vehicle support.type.tensor.vehicle
-#                            ^ source.vehicle
-#                             ^^^ source.vehicle support.type.rat.vehicle
-#                                ^^ source.vehicle
-#                                  ^ source.vehicle constant.numeric.integral.decimal.vehicle
-#                                   ^^ source.vehicle
+#           ^^^^ source.vehicle support.type.rat.vehicle
+#               ^^ source.vehicle
+#                 ^ source.vehicle constant.numeric.integral.decimal.vehicle
+#                  ^^ source.vehicle
+#                    ^^ source.vehicle keyword.operator.arrow.vehicle
+#                      ^ source.vehicle
+#                       ^^^^^^ source.vehicle support.type.tensor.vehicle
+#                             ^ source.vehicle
+#                              ^^^^ source.vehicle support.type.rat.vehicle
+#                                  ^^ source.vehicle
+#                                    ^ source.vehicle constant.numeric.integral.decimal.vehicle
+#                                     ^^ source.vehicle
 >
 >@property
 #^^^^^^^^^ source.vehicle keyword.other.declaration.property.vehicle

--- a/tests/snap/alternatingFun.vcl
+++ b/tests/snap/alternatingFun.vcl
@@ -1,9 +1,9 @@
 @network
-f : Tensor Rat [1] -> Tensor Rat [1]
+f : Tensor Real [1] -> Tensor Real [1]
 
-existential : Rat -> Bool
+existential : Real -> Bool
 existential y = exists x . x >= y
 
 @property
 p : Bool
-p = forall (y : Rat) . existential y
+p = forall (y : Real) . existential y

--- a/tests/snap/alternatingFun.vcl.snap
+++ b/tests/snap/alternatingFun.vcl.snap
@@ -1,33 +1,33 @@
 >@network
 #^^^^^^^^ source.vehicle keyword.other.declaration.network.vehicle
->f : Tensor Rat [1] -> Tensor Rat [1]
+>f : Tensor Real [1] -> Tensor Real [1]
 #^^ source.vehicle
 #  ^ source.vehicle keyword.operator.colon.vehicle
 #   ^ source.vehicle
 #    ^^^^^^ source.vehicle support.type.tensor.vehicle
 #          ^ source.vehicle
-#           ^^^ source.vehicle support.type.rat.vehicle
-#              ^^ source.vehicle
-#                ^ source.vehicle constant.numeric.integral.decimal.vehicle
-#                 ^^ source.vehicle
-#                   ^^ source.vehicle keyword.operator.arrow.vehicle
-#                     ^ source.vehicle
-#                      ^^^^^^ source.vehicle support.type.tensor.vehicle
-#                            ^ source.vehicle
-#                             ^^^ source.vehicle support.type.rat.vehicle
-#                                ^^ source.vehicle
-#                                  ^ source.vehicle constant.numeric.integral.decimal.vehicle
-#                                   ^^ source.vehicle
+#           ^^^^ source.vehicle support.type.rat.vehicle
+#               ^^ source.vehicle
+#                 ^ source.vehicle constant.numeric.integral.decimal.vehicle
+#                  ^^ source.vehicle
+#                    ^^ source.vehicle keyword.operator.arrow.vehicle
+#                      ^ source.vehicle
+#                       ^^^^^^ source.vehicle support.type.tensor.vehicle
+#                             ^ source.vehicle
+#                              ^^^^ source.vehicle support.type.rat.vehicle
+#                                  ^^ source.vehicle
+#                                    ^ source.vehicle constant.numeric.integral.decimal.vehicle
+#                                     ^^ source.vehicle
 >
->existential : Rat -> Bool
+>existential : Real -> Bool
 #^^^^^^^^^^^^ source.vehicle
 #            ^ source.vehicle keyword.operator.colon.vehicle
 #             ^ source.vehicle
-#              ^^^ source.vehicle support.type.rat.vehicle
-#                 ^ source.vehicle
-#                  ^^ source.vehicle keyword.operator.arrow.vehicle
-#                    ^ source.vehicle
-#                     ^^^^ source.vehicle support.type.bool.vehicle
+#              ^^^^ source.vehicle support.type.rat.vehicle
+#                  ^ source.vehicle
+#                   ^^ source.vehicle keyword.operator.arrow.vehicle
+#                     ^ source.vehicle
+#                      ^^^^ source.vehicle support.type.bool.vehicle
 >existential y = exists x . x >= y
 #^^^^^^^^^^^^^^ source.vehicle
 #              ^ source.vehicle keyword.operator.define.vehicle
@@ -46,7 +46,7 @@
 #  ^ source.vehicle keyword.operator.colon.vehicle
 #   ^ source.vehicle
 #    ^^^^ source.vehicle support.type.bool.vehicle
->p = forall (y : Rat) . existential y
+>p = forall (y : Real) . existential y
 #^^ source.vehicle
 #  ^ source.vehicle keyword.operator.define.vehicle
 #   ^ source.vehicle
@@ -54,8 +54,8 @@
 #          ^^^^ source.vehicle
 #              ^ source.vehicle keyword.operator.colon.vehicle
 #               ^ source.vehicle
-#                ^^^ source.vehicle support.type.rat.vehicle
-#                   ^^ source.vehicle
-#                     ^ source.vehicle keyword.operator.dot.vehicle
-#                      ^^^^^^^^^^^^^^^ source.vehicle
+#                ^^^^ source.vehicle support.type.rat.vehicle
+#                    ^^ source.vehicle
+#                      ^ source.vehicle keyword.operator.dot.vehicle
+#                       ^^^^^^^^^^^^^^^ source.vehicle
 >

--- a/tests/snap/alternatingImplies.vcl
+++ b/tests/snap/alternatingImplies.vcl
@@ -1,5 +1,5 @@
 @network
-f : Tensor Rat [1] -> Tensor Rat [1]
+f : Tensor Real [1] -> Tensor Real [1]
 
 @property
 p : Bool

--- a/tests/snap/alternatingImplies.vcl.snap
+++ b/tests/snap/alternatingImplies.vcl.snap
@@ -1,23 +1,23 @@
 >@network
 #^^^^^^^^ source.vehicle keyword.other.declaration.network.vehicle
->f : Tensor Rat [1] -> Tensor Rat [1]
+>f : Tensor Real [1] -> Tensor Real [1]
 #^^ source.vehicle
 #  ^ source.vehicle keyword.operator.colon.vehicle
 #   ^ source.vehicle
 #    ^^^^^^ source.vehicle support.type.tensor.vehicle
 #          ^ source.vehicle
-#           ^^^ source.vehicle support.type.rat.vehicle
-#              ^^ source.vehicle
-#                ^ source.vehicle constant.numeric.integral.decimal.vehicle
-#                 ^^ source.vehicle
-#                   ^^ source.vehicle keyword.operator.arrow.vehicle
-#                     ^ source.vehicle
-#                      ^^^^^^ source.vehicle support.type.tensor.vehicle
-#                            ^ source.vehicle
-#                             ^^^ source.vehicle support.type.rat.vehicle
-#                                ^^ source.vehicle
-#                                  ^ source.vehicle constant.numeric.integral.decimal.vehicle
-#                                   ^^ source.vehicle
+#           ^^^^ source.vehicle support.type.rat.vehicle
+#               ^^ source.vehicle
+#                 ^ source.vehicle constant.numeric.integral.decimal.vehicle
+#                  ^^ source.vehicle
+#                    ^^ source.vehicle keyword.operator.arrow.vehicle
+#                      ^ source.vehicle
+#                       ^^^^^^ source.vehicle support.type.tensor.vehicle
+#                             ^ source.vehicle
+#                              ^^^^ source.vehicle support.type.rat.vehicle
+#                                  ^^ source.vehicle
+#                                    ^ source.vehicle constant.numeric.integral.decimal.vehicle
+#                                     ^^ source.vehicle
 >
 >@property
 #^^^^^^^^^ source.vehicle keyword.other.declaration.property.vehicle

--- a/tests/snap/alternatingIndirectNegFun.vcl
+++ b/tests/snap/alternatingIndirectNegFun.vcl
@@ -1,11 +1,11 @@
 @network
-f : Tensor Rat [1] -> Tensor Rat [1]
+f : Tensor Real [1] -> Tensor Real [1]
 
-myForall : Rat -> Bool
+myForall : Real -> Bool
 myForall y = forall x . f x ! 0 >= y
 
-notApp : (Rat -> Bool) -> Rat -> Bool
-notApp (f : Rat -> Bool) x = not (f x)
+notApp : (Real -> Bool) -> Real -> Bool
+notApp (f : Real -> Bool) x = not (f x)
 
 @property
 p : Bool

--- a/tests/snap/alternatingIndirectNegFun.vcl.snap
+++ b/tests/snap/alternatingIndirectNegFun.vcl.snap
@@ -1,35 +1,35 @@
 >@network
 #^^^^^^^^ source.vehicle keyword.other.declaration.network.vehicle
->f : Tensor Rat [1] -> Tensor Rat [1]
+>f : Tensor Real [1] -> Tensor Real [1]
 #^^ source.vehicle
 #  ^ source.vehicle keyword.operator.colon.vehicle
 #   ^ source.vehicle
 #    ^^^^^^ source.vehicle support.type.tensor.vehicle
 #          ^ source.vehicle
-#           ^^^ source.vehicle support.type.rat.vehicle
-#              ^^ source.vehicle
-#                ^ source.vehicle constant.numeric.integral.decimal.vehicle
-#                 ^^ source.vehicle
-#                   ^^ source.vehicle keyword.operator.arrow.vehicle
-#                     ^ source.vehicle
-#                      ^^^^^^ source.vehicle support.type.tensor.vehicle
-#                            ^ source.vehicle
-#                             ^^^ source.vehicle support.type.rat.vehicle
-#                                ^^ source.vehicle
-#                                  ^ source.vehicle constant.numeric.integral.decimal.vehicle
-#                                   ^^ source.vehicle
+#           ^^^^ source.vehicle support.type.rat.vehicle
+#               ^^ source.vehicle
+#                 ^ source.vehicle constant.numeric.integral.decimal.vehicle
+#                  ^^ source.vehicle
+#                    ^^ source.vehicle keyword.operator.arrow.vehicle
+#                      ^ source.vehicle
+#                       ^^^^^^ source.vehicle support.type.tensor.vehicle
+#                             ^ source.vehicle
+#                              ^^^^ source.vehicle support.type.rat.vehicle
+#                                  ^^ source.vehicle
+#                                    ^ source.vehicle constant.numeric.integral.decimal.vehicle
+#                                     ^^ source.vehicle
 >
->myForall : Rat -> Bool
+>myForall : Real -> Bool
 #^^^ source.vehicle
 #   ^^ source.vehicle keyword.operator.or.vehicle
 #     ^^^^ source.vehicle
 #         ^ source.vehicle keyword.operator.colon.vehicle
 #          ^ source.vehicle
-#           ^^^ source.vehicle support.type.rat.vehicle
-#              ^ source.vehicle
-#               ^^ source.vehicle keyword.operator.arrow.vehicle
-#                 ^ source.vehicle
-#                  ^^^^ source.vehicle support.type.bool.vehicle
+#           ^^^^ source.vehicle support.type.rat.vehicle
+#               ^ source.vehicle
+#                ^^ source.vehicle keyword.operator.arrow.vehicle
+#                  ^ source.vehicle
+#                   ^^^^ source.vehicle support.type.bool.vehicle
 >myForall y = forall x . f x ! 0 >= y
 #^^^ source.vehicle
 #   ^^ source.vehicle keyword.operator.or.vehicle
@@ -47,37 +47,37 @@
 #                                ^^ source.vehicle keyword.operator.gte.vehicle
 #                                  ^^^ source.vehicle
 >
->notApp : (Rat -> Bool) -> Rat -> Bool
+>notApp : (Real -> Bool) -> Real -> Bool
 #^^^^^^^ source.vehicle
 #       ^ source.vehicle keyword.operator.colon.vehicle
 #        ^^ source.vehicle
-#          ^^^ source.vehicle support.type.rat.vehicle
-#             ^ source.vehicle
-#              ^^ source.vehicle keyword.operator.arrow.vehicle
-#                ^ source.vehicle
-#                 ^^^^ source.vehicle support.type.bool.vehicle
-#                     ^^ source.vehicle
-#                       ^^ source.vehicle keyword.operator.arrow.vehicle
-#                         ^ source.vehicle
-#                          ^^^ source.vehicle support.type.rat.vehicle
-#                             ^ source.vehicle
-#                              ^^ source.vehicle keyword.operator.arrow.vehicle
-#                                ^ source.vehicle
-#                                 ^^^^ source.vehicle support.type.bool.vehicle
->notApp (f : Rat -> Bool) x = not (f x)
+#          ^^^^ source.vehicle support.type.rat.vehicle
+#              ^ source.vehicle
+#               ^^ source.vehicle keyword.operator.arrow.vehicle
+#                 ^ source.vehicle
+#                  ^^^^ source.vehicle support.type.bool.vehicle
+#                      ^^ source.vehicle
+#                        ^^ source.vehicle keyword.operator.arrow.vehicle
+#                          ^ source.vehicle
+#                           ^^^^ source.vehicle support.type.rat.vehicle
+#                               ^ source.vehicle
+#                                ^^ source.vehicle keyword.operator.arrow.vehicle
+#                                  ^ source.vehicle
+#                                   ^^^^ source.vehicle support.type.bool.vehicle
+>notApp (f : Real -> Bool) x = not (f x)
 #^^^^^^^^^^ source.vehicle
 #          ^ source.vehicle keyword.operator.colon.vehicle
 #           ^ source.vehicle
-#            ^^^ source.vehicle support.type.rat.vehicle
-#               ^ source.vehicle
-#                ^^ source.vehicle keyword.operator.arrow.vehicle
-#                  ^ source.vehicle
-#                   ^^^^ source.vehicle support.type.bool.vehicle
-#                       ^^^^ source.vehicle
-#                           ^ source.vehicle keyword.operator.define.vehicle
-#                            ^ source.vehicle
-#                             ^^^ source.vehicle constant.language.not.vehicle
-#                                ^^^^^^^ source.vehicle
+#            ^^^^ source.vehicle support.type.rat.vehicle
+#                ^ source.vehicle
+#                 ^^ source.vehicle keyword.operator.arrow.vehicle
+#                   ^ source.vehicle
+#                    ^^^^ source.vehicle support.type.bool.vehicle
+#                        ^^^^ source.vehicle
+#                            ^ source.vehicle keyword.operator.define.vehicle
+#                             ^ source.vehicle
+#                              ^^^ source.vehicle constant.language.not.vehicle
+#                                 ^^^^^^^ source.vehicle
 >
 >@property
 #^^^^^^^^^ source.vehicle keyword.other.declaration.property.vehicle

--- a/tests/snap/alternatingIndirectNegFun.vcl.snap
+++ b/tests/snap/alternatingIndirectNegFun.vcl.snap
@@ -20,9 +20,7 @@
 #                                     ^^ source.vehicle
 >
 >myForall : Real -> Bool
-#^^^ source.vehicle
-#   ^^ source.vehicle keyword.operator.or.vehicle
-#     ^^^^ source.vehicle
+#^^^^^^^^^ source.vehicle
 #         ^ source.vehicle keyword.operator.colon.vehicle
 #          ^ source.vehicle
 #           ^^^^ source.vehicle support.type.rat.vehicle
@@ -31,9 +29,7 @@
 #                  ^ source.vehicle
 #                   ^^^^ source.vehicle support.type.bool.vehicle
 >myForall y = forall x . f x ! 0 >= y
-#^^^ source.vehicle
-#   ^^ source.vehicle keyword.operator.or.vehicle
-#     ^^^^^^ source.vehicle
+#^^^^^^^^^^^ source.vehicle
 #           ^ source.vehicle keyword.operator.define.vehicle
 #            ^ source.vehicle
 #             ^^^^^^ source.vehicle keyword.control.forall.vehicle
@@ -93,7 +89,5 @@
 #    ^^^^^^ source.vehicle keyword.control.forall.vehicle
 #          ^^^ source.vehicle
 #             ^ source.vehicle keyword.operator.dot.vehicle
-#              ^^^^^^^^^^^ source.vehicle
-#                         ^^ source.vehicle keyword.operator.or.vehicle
-#                           ^^^^^^ source.vehicle
+#              ^^^^^^^^^^^^^^^^^^^ source.vehicle
 >

--- a/tests/snap/alternatingNeg.vcl
+++ b/tests/snap/alternatingNeg.vcl
@@ -1,5 +1,5 @@
 @network
-f : Tensor Rat [1] -> Tensor Rat [1]
+f : Tensor Real [1] -> Tensor Real [1]
 
 @property
 p : Bool

--- a/tests/snap/alternatingNeg.vcl.snap
+++ b/tests/snap/alternatingNeg.vcl.snap
@@ -1,23 +1,23 @@
 >@network
 #^^^^^^^^ source.vehicle keyword.other.declaration.network.vehicle
->f : Tensor Rat [1] -> Tensor Rat [1]
+>f : Tensor Real [1] -> Tensor Real [1]
 #^^ source.vehicle
 #  ^ source.vehicle keyword.operator.colon.vehicle
 #   ^ source.vehicle
 #    ^^^^^^ source.vehicle support.type.tensor.vehicle
 #          ^ source.vehicle
-#           ^^^ source.vehicle support.type.rat.vehicle
-#              ^^ source.vehicle
-#                ^ source.vehicle constant.numeric.integral.decimal.vehicle
-#                 ^^ source.vehicle
-#                   ^^ source.vehicle keyword.operator.arrow.vehicle
-#                     ^ source.vehicle
-#                      ^^^^^^ source.vehicle support.type.tensor.vehicle
-#                            ^ source.vehicle
-#                             ^^^ source.vehicle support.type.rat.vehicle
-#                                ^^ source.vehicle
-#                                  ^ source.vehicle constant.numeric.integral.decimal.vehicle
-#                                   ^^ source.vehicle
+#           ^^^^ source.vehicle support.type.rat.vehicle
+#               ^^ source.vehicle
+#                 ^ source.vehicle constant.numeric.integral.decimal.vehicle
+#                  ^^ source.vehicle
+#                    ^^ source.vehicle keyword.operator.arrow.vehicle
+#                      ^ source.vehicle
+#                       ^^^^^^ source.vehicle support.type.tensor.vehicle
+#                             ^ source.vehicle
+#                              ^^^^ source.vehicle support.type.rat.vehicle
+#                                  ^^ source.vehicle
+#                                    ^ source.vehicle constant.numeric.integral.decimal.vehicle
+#                                     ^^ source.vehicle
 >
 >@property
 #^^^^^^^^^ source.vehicle keyword.other.declaration.property.vehicle

--- a/tests/snap/alternatingNegNeg.vcl
+++ b/tests/snap/alternatingNegNeg.vcl
@@ -1,5 +1,5 @@
 @network
-f : Tensor Rat [1] -> Tensor Rat [1]
+f : Tensor Real [1] -> Tensor Real [1]
 
 @property
 p : Bool

--- a/tests/snap/alternatingNegNeg.vcl.snap
+++ b/tests/snap/alternatingNegNeg.vcl.snap
@@ -1,23 +1,23 @@
 >@network
 #^^^^^^^^ source.vehicle keyword.other.declaration.network.vehicle
->f : Tensor Rat [1] -> Tensor Rat [1]
+>f : Tensor Real [1] -> Tensor Real [1]
 #^^ source.vehicle
 #  ^ source.vehicle keyword.operator.colon.vehicle
 #   ^ source.vehicle
 #    ^^^^^^ source.vehicle support.type.tensor.vehicle
 #          ^ source.vehicle
-#           ^^^ source.vehicle support.type.rat.vehicle
-#              ^^ source.vehicle
-#                ^ source.vehicle constant.numeric.integral.decimal.vehicle
-#                 ^^ source.vehicle
-#                   ^^ source.vehicle keyword.operator.arrow.vehicle
-#                     ^ source.vehicle
-#                      ^^^^^^ source.vehicle support.type.tensor.vehicle
-#                            ^ source.vehicle
-#                             ^^^ source.vehicle support.type.rat.vehicle
-#                                ^^ source.vehicle
-#                                  ^ source.vehicle constant.numeric.integral.decimal.vehicle
-#                                   ^^ source.vehicle
+#           ^^^^ source.vehicle support.type.rat.vehicle
+#               ^^ source.vehicle
+#                 ^ source.vehicle constant.numeric.integral.decimal.vehicle
+#                  ^^ source.vehicle
+#                    ^^ source.vehicle keyword.operator.arrow.vehicle
+#                      ^ source.vehicle
+#                       ^^^^^^ source.vehicle support.type.tensor.vehicle
+#                             ^ source.vehicle
+#                              ^^^^ source.vehicle support.type.rat.vehicle
+#                                  ^^ source.vehicle
+#                                    ^ source.vehicle constant.numeric.integral.decimal.vehicle
+#                                     ^^ source.vehicle
 >
 >@property
 #^^^^^^^^^ source.vehicle keyword.other.declaration.property.vehicle

--- a/tests/snap/duplicateVariableName.vcl
+++ b/tests/snap/duplicateVariableName.vcl
@@ -1,6 +1,6 @@
 @network
-f : Vector Rat 1 -> Vector Rat 1
+f : Vector Real 1 -> Vector Real 1
 
 @property
 property : Bool
-property = forall (x : Rat) . x >= 0 and (forall x . f x >= 0)
+property = forall (x : Real) . x >= 0 and (forall x . f x >= 0)

--- a/tests/snap/duplicateVariableName.vcl.snap
+++ b/tests/snap/duplicateVariableName.vcl.snap
@@ -1,22 +1,22 @@
 >@network
 #^^^^^^^^ source.vehicle keyword.other.declaration.network.vehicle
->f : Vector Rat 1 -> Vector Rat 1
+>f : Vector Real 1 -> Vector Real 1
 #^^ source.vehicle
 #  ^ source.vehicle keyword.operator.colon.vehicle
 #   ^ source.vehicle
 #    ^^^^^^ source.vehicle support.type.vector.vehicle
 #          ^ source.vehicle
-#           ^^^ source.vehicle support.type.rat.vehicle
-#              ^ source.vehicle
-#               ^ source.vehicle constant.numeric.integral.decimal.vehicle
-#                ^ source.vehicle
-#                 ^^ source.vehicle keyword.operator.arrow.vehicle
-#                   ^ source.vehicle
-#                    ^^^^^^ source.vehicle support.type.vector.vehicle
-#                          ^ source.vehicle
-#                           ^^^ source.vehicle support.type.rat.vehicle
-#                              ^ source.vehicle
-#                               ^ source.vehicle constant.numeric.integral.decimal.vehicle
+#           ^^^^ source.vehicle support.type.rat.vehicle
+#               ^ source.vehicle
+#                ^ source.vehicle constant.numeric.integral.decimal.vehicle
+#                 ^ source.vehicle
+#                  ^^ source.vehicle keyword.operator.arrow.vehicle
+#                    ^ source.vehicle
+#                     ^^^^^^ source.vehicle support.type.vector.vehicle
+#                           ^ source.vehicle
+#                            ^^^^ source.vehicle support.type.rat.vehicle
+#                                ^ source.vehicle
+#                                 ^ source.vehicle constant.numeric.integral.decimal.vehicle
 >
 >@property
 #^^^^^^^^^ source.vehicle keyword.other.declaration.property.vehicle
@@ -25,7 +25,7 @@
 #         ^ source.vehicle keyword.operator.colon.vehicle
 #          ^ source.vehicle
 #           ^^^^ source.vehicle support.type.bool.vehicle
->property = forall (x : Rat) . x >= 0 and (forall x . f x >= 0)
+>property = forall (x : Real) . x >= 0 and (forall x . f x >= 0)
 #^^^^^^^^^ source.vehicle
 #         ^ source.vehicle keyword.operator.define.vehicle
 #          ^ source.vehicle
@@ -33,22 +33,22 @@
 #                 ^^^^ source.vehicle
 #                     ^ source.vehicle keyword.operator.colon.vehicle
 #                      ^ source.vehicle
-#                       ^^^ source.vehicle support.type.rat.vehicle
-#                          ^^ source.vehicle
-#                            ^ source.vehicle keyword.operator.dot.vehicle
-#                             ^^^ source.vehicle
-#                                ^^ source.vehicle keyword.operator.gte.vehicle
-#                                  ^ source.vehicle
-#                                   ^ source.vehicle constant.numeric.integral.decimal.vehicle
-#                                    ^ source.vehicle
-#                                     ^^^ source.vehicle keyword.operator.and.vehicle
-#                                        ^^ source.vehicle
-#                                          ^^^^^^ source.vehicle keyword.control.forall.vehicle
-#                                                ^^^ source.vehicle
-#                                                   ^ source.vehicle keyword.operator.dot.vehicle
-#                                                    ^^^^^ source.vehicle
-#                                                         ^^ source.vehicle keyword.operator.gte.vehicle
-#                                                           ^ source.vehicle
-#                                                            ^ source.vehicle constant.numeric.integral.decimal.vehicle
-#                                                             ^^ source.vehicle
+#                       ^^^^ source.vehicle support.type.rat.vehicle
+#                           ^^ source.vehicle
+#                             ^ source.vehicle keyword.operator.dot.vehicle
+#                              ^^^ source.vehicle
+#                                 ^^ source.vehicle keyword.operator.gte.vehicle
+#                                   ^ source.vehicle
+#                                    ^ source.vehicle constant.numeric.integral.decimal.vehicle
+#                                     ^ source.vehicle
+#                                      ^^^ source.vehicle keyword.operator.and.vehicle
+#                                         ^^ source.vehicle
+#                                           ^^^^^^ source.vehicle keyword.control.forall.vehicle
+#                                                 ^^^ source.vehicle
+#                                                    ^ source.vehicle keyword.operator.dot.vehicle
+#                                                     ^^^^^ source.vehicle
+#                                                          ^^ source.vehicle keyword.operator.gte.vehicle
+#                                                            ^ source.vehicle
+#                                                             ^ source.vehicle constant.numeric.integral.decimal.vehicle
+#                                                              ^^ source.vehicle
 >

--- a/tests/snap/incorrectTensorLength.vcl.snap
+++ b/tests/snap/incorrectTensorLength.vcl.snap
@@ -1,7 +1,5 @@
 >tensor : Vector Nat 2
-#^^^^ source.vehicle
-#    ^^ source.vehicle keyword.operator.or.vehicle
-#      ^ source.vehicle
+#^^^^^^^ source.vehicle
 #       ^ source.vehicle keyword.operator.colon.vehicle
 #        ^ source.vehicle
 #         ^^^^^^ source.vehicle support.type.vector.vehicle
@@ -10,9 +8,7 @@
 #                   ^ source.vehicle
 #                    ^ source.vehicle constant.numeric.integral.decimal.vehicle
 >tensor = [1]
-#^^^^ source.vehicle
-#    ^^ source.vehicle keyword.operator.or.vehicle
-#      ^ source.vehicle
+#^^^^^^^ source.vehicle
 #       ^ source.vehicle keyword.operator.define.vehicle
 #        ^^ source.vehicle
 #          ^ source.vehicle constant.numeric.integral.decimal.vehicle

--- a/tests/snap/invalidAnnotationParameter.vcl
+++ b/tests/snap/invalidAnnotationParameter.vcl
@@ -1,2 +1,2 @@
 @parameter(valid=False)
-epsilon : Rat
+epsilon : Real

--- a/tests/snap/invalidAnnotationParameter.vcl.snap
+++ b/tests/snap/invalidAnnotationParameter.vcl.snap
@@ -4,9 +4,9 @@
 #                ^ source.vehicle keyword.operator.define.vehicle
 #                 ^^^^^ source.vehicle constant.language.false.vehicle
 #                      ^^ source.vehicle
->epsilon : Rat
+>epsilon : Real
 #^^^^^^^^ source.vehicle
 #        ^ source.vehicle keyword.operator.colon.vehicle
 #         ^ source.vehicle
-#          ^^^ source.vehicle support.type.rat.vehicle
+#          ^^^^ source.vehicle support.type.rat.vehicle
 >

--- a/tests/snap/invalidAnnotationParameterValue.vcl
+++ b/tests/snap/invalidAnnotationParameterValue.vcl
@@ -1,2 +1,2 @@
 @parameter(implicit=xsd)
-epsilon : Rat
+epsilon : Real

--- a/tests/snap/invalidAnnotationParameterValue.vcl.snap
+++ b/tests/snap/invalidAnnotationParameterValue.vcl.snap
@@ -3,9 +3,9 @@
 #          ^^^^^^^^^ source.vehicle
 #                   ^ source.vehicle keyword.operator.define.vehicle
 #                    ^^^^^ source.vehicle
->epsilon : Rat
+>epsilon : Real
 #^^^^^^^^ source.vehicle
 #        ^ source.vehicle keyword.operator.colon.vehicle
 #         ^ source.vehicle
-#          ^^^ source.vehicle support.type.rat.vehicle
+#          ^^^^ source.vehicle support.type.rat.vehicle
 >

--- a/tests/snap/invalidType.vcl
+++ b/tests/snap/invalidType.vcl
@@ -1,3 +1,3 @@
 @property
-p : Rat
+p : Real
 p = 0.1

--- a/tests/snap/invalidType.vcl.snap
+++ b/tests/snap/invalidType.vcl.snap
@@ -1,10 +1,10 @@
 >@property
 #^^^^^^^^^ source.vehicle keyword.other.declaration.property.vehicle
->p : Rat
+>p : Real
 #^^ source.vehicle
 #  ^ source.vehicle keyword.operator.colon.vehicle
 #   ^ source.vehicle
-#    ^^^ source.vehicle support.type.rat.vehicle
+#    ^^^^ source.vehicle support.type.rat.vehicle
 >p = 0.1
 #^^ source.vehicle
 #  ^ source.vehicle keyword.operator.define.vehicle

--- a/tests/snap/mismatchedType.vcl
+++ b/tests/snap/mismatchedType.vcl
@@ -1,3 +1,3 @@
--- Test passes dataset of type List Rat
+-- Test passes dataset of type List Real
 @dataset
 trainingDataset : List Int

--- a/tests/snap/mismatchedType.vcl.snap
+++ b/tests/snap/mismatchedType.vcl.snap
@@ -1,6 +1,6 @@
->-- Test passes dataset of type List Rat
+>-- Test passes dataset of type List Real
 #^^ source.vehicle comment.line.double-dash.vehicle punctuation.definition.comment.vehicle
-#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.vehicle comment.line.double-dash.vehicle
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.vehicle comment.line.double-dash.vehicle
 >@dataset
 #^^^^^^^^ source.vehicle keyword.other.declaration.dataset.vehicle
 >trainingDataset : List Int

--- a/tests/snap/missingDataset.vcl
+++ b/tests/snap/missingDataset.vcl
@@ -1,3 +1,3 @@
 -- Test passes a reference to a non-existent dataset
 @dataset
-trainingDataset : List Rat
+trainingDataset : List Real

--- a/tests/snap/missingDataset.vcl.snap
+++ b/tests/snap/missingDataset.vcl.snap
@@ -3,11 +3,11 @@
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.vehicle comment.line.double-dash.vehicle
 >@dataset
 #^^^^^^^^ source.vehicle keyword.other.declaration.dataset.vehicle
->trainingDataset : List Rat
+>trainingDataset : List Real
 #^^^^^^^^^^^^^^^^ source.vehicle
 #                ^ source.vehicle keyword.operator.colon.vehicle
 #                 ^ source.vehicle
 #                  ^^^^ source.vehicle support.type.list.vehicle
 #                      ^ source.vehicle
-#                       ^^^ source.vehicle support.type.rat.vehicle
+#                       ^^^^ source.vehicle support.type.rat.vehicle
 >

--- a/tests/snap/mnist-robustness.vcl
+++ b/tests/snap/mnist-robustness.vcl
@@ -2,7 +2,7 @@
 -- Inputs and outputs
 
 -- Define the type for our input images
-type Image = Tensor Rat [28, 28]
+type Image = Tensor Real [28, 28]
 
 -- The type of the output labels
 -- i.e a number between 0 and 9, one for each digit
@@ -19,7 +19,7 @@ validImage x = forall i j . 0 <= x ! i ! j <= 1
 -- Declare the network used to classify images. The output of the network is a
 -- score for each of the digits 0 to 9.
 @network
-classifier : Image -> Vector Rat 10
+classifier : Image -> Vector Real 10
 
 -- The classifier advises that input image `x` has label `i` if the score
 -- for label `i` is greater than the score of any other label `j`.
@@ -34,7 +34,7 @@ advises x i = forall j . j != i => classifier x ! i > classifier x ! j
 -- a parameter which allows the value of `epsilon` to be specified at compile
 -- time rather than be fixed in the specification.
 @parameter
-epsilon : Rat
+epsilon : Real
 
 -- Next we define what it means for an image `x` to be in a ball of
 -- size epsilon around 0.

--- a/tests/snap/mnist-robustness.vcl.snap
+++ b/tests/snap/mnist-robustness.vcl.snap
@@ -8,19 +8,19 @@
 >-- Define the type for our input images
 #^^ source.vehicle comment.line.double-dash.vehicle punctuation.definition.comment.vehicle
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.vehicle comment.line.double-dash.vehicle
->type Image = Tensor Rat [28, 28]
+>type Image = Tensor Real [28, 28]
 #^^^^ source.vehicle keyword.other.declaration.type.vehicle
 #    ^^^^^^^ source.vehicle
 #           ^ source.vehicle keyword.operator.define.vehicle
 #            ^ source.vehicle
 #             ^^^^^^ source.vehicle support.type.tensor.vehicle
 #                   ^ source.vehicle
-#                    ^^^ source.vehicle support.type.rat.vehicle
-#                       ^^ source.vehicle
-#                         ^^ source.vehicle constant.numeric.integral.decimal.vehicle
-#                           ^^ source.vehicle
-#                             ^^ source.vehicle constant.numeric.integral.decimal.vehicle
-#                               ^^ source.vehicle
+#                    ^^^^ source.vehicle support.type.rat.vehicle
+#                        ^^ source.vehicle
+#                          ^^ source.vehicle constant.numeric.integral.decimal.vehicle
+#                            ^^ source.vehicle
+#                              ^^ source.vehicle constant.numeric.integral.decimal.vehicle
+#                                ^^ source.vehicle
 >
 >-- The type of the output labels
 #^^ source.vehicle comment.line.double-dash.vehicle punctuation.definition.comment.vehicle
@@ -85,7 +85,7 @@
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.vehicle comment.line.double-dash.vehicle
 >@network
 #^^^^^^^^ source.vehicle keyword.other.declaration.network.vehicle
->classifier : Image -> Vector Rat 10
+>classifier : Image -> Vector Real 10
 #^^^^^^^^^^^ source.vehicle
 #           ^ source.vehicle keyword.operator.colon.vehicle
 #            ^^^^^^^ source.vehicle
@@ -93,9 +93,9 @@
 #                     ^ source.vehicle
 #                      ^^^^^^ source.vehicle support.type.vector.vehicle
 #                            ^ source.vehicle
-#                             ^^^ source.vehicle support.type.rat.vehicle
-#                                ^ source.vehicle
-#                                 ^^ source.vehicle constant.numeric.integral.decimal.vehicle
+#                             ^^^^ source.vehicle support.type.rat.vehicle
+#                                 ^ source.vehicle
+#                                  ^^ source.vehicle constant.numeric.integral.decimal.vehicle
 >
 >-- The classifier advises that input image `x` has label `i` if the score
 #^^ source.vehicle comment.line.double-dash.vehicle punctuation.definition.comment.vehicle
@@ -152,11 +152,11 @@
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.vehicle comment.line.double-dash.vehicle
 >@parameter
 #^^^^^^^^^^ source.vehicle keyword.other.declaration.parameter.vehicle
->epsilon : Rat
+>epsilon : Real
 #^^^^^^^^ source.vehicle
 #        ^ source.vehicle keyword.operator.colon.vehicle
 #         ^ source.vehicle
-#          ^^^ source.vehicle support.type.rat.vehicle
+#          ^^^^ source.vehicle support.type.rat.vehicle
 >
 >-- Next we define what it means for an image `x` to be in a ball of
 #^^ source.vehicle comment.line.double-dash.vehicle punctuation.definition.comment.vehicle

--- a/tests/snap/mnist.vcl
+++ b/tests/snap/mnist.vcl
@@ -2,7 +2,7 @@
 -- Inputs and outputs
 
 -- Define the type for our input images
---type Image = Tensor Rat [28, 28]
+--type Image = Tensor Real [28, 28]
 
 --------------------------------------------------------------------------------
 -- Network
@@ -10,7 +10,7 @@
 -- Declare the network used to classify images. The output of the network is a
 -- score for each of the digits 0 to 9.
 @network
-mnist : Tensor Rat [28, 28] -> Vector Rat 10
+mnist : Tensor Real [28, 28] -> Vector Real 10
 
 --------------------------------------------------------------------------------
 -- Definition of robustness around a point
@@ -20,23 +20,23 @@ mnist : Tensor Rat [28, 28] -> Vector Rat 10
 -- a parameter which allows the value of `epsilon` to be specified at compile
 -- time rather than be fixed in the specification.
 
---epsilon : Rat
+--epsilon : Real
 --epsilon = 0.01
 
---delta : Rat
+--delta : Real
 --delta = 0.02
 
 -- Next we define what it means for an image `x` to be in a ball of
 -- size epsilon around 0.
-boundedByEpsilon : Tensor Rat [28, 28] -> Bool
+boundedByEpsilon : Tensor Real [28, 28] -> Bool
 boundedByEpsilon x = forall i j . -0.01 <= x ! i ! j <= 0.01
 
 --The disjunction avoids having to define absolute value
-boundedByDelta : Tensor Rat [28, 28] -> Tensor Rat [28, 28] -> Bool
+boundedByDelta : Tensor Real [28, 28] -> Tensor Real [28, 28] -> Bool
 boundedByDelta x y = forall k . (-0.02 <= (((mnist x) ! k ) - ((mnist y) ! k )) <= 0.02)
 
 
-robustSingleInput : Tensor Rat [28, 28] -> Bool
+robustSingleInput : Tensor Real [28, 28] -> Bool
 robustSingleInput image = forall pertubation .
     let perturbedImage = image + pertubation in
     boundedByEpsilon pertubation => boundedByDelta image perturbedImage

--- a/tests/snap/mnist.vcl.snap
+++ b/tests/snap/mnist.vcl.snap
@@ -8,9 +8,9 @@
 >-- Define the type for our input images
 #^^ source.vehicle comment.line.double-dash.vehicle punctuation.definition.comment.vehicle
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.vehicle comment.line.double-dash.vehicle
->--type Image = Tensor Rat [28, 28]
+>--type Image = Tensor Real [28, 28]
 #^^ source.vehicle comment.line.double-dash.vehicle punctuation.definition.comment.vehicle
-#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.vehicle comment.line.double-dash.vehicle
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.vehicle comment.line.double-dash.vehicle
 >
 >--------------------------------------------------------------------------------
 #^^ source.vehicle comment.line.double-dash.vehicle punctuation.definition.comment.vehicle
@@ -27,25 +27,25 @@
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.vehicle comment.line.double-dash.vehicle
 >@network
 #^^^^^^^^ source.vehicle keyword.other.declaration.network.vehicle
->mnist : Tensor Rat [28, 28] -> Vector Rat 10
+>mnist : Tensor Real [28, 28] -> Vector Real 10
 #^^^^^^ source.vehicle
 #      ^ source.vehicle keyword.operator.colon.vehicle
 #       ^ source.vehicle
 #        ^^^^^^ source.vehicle support.type.tensor.vehicle
 #              ^ source.vehicle
-#               ^^^ source.vehicle support.type.rat.vehicle
-#                  ^^ source.vehicle
-#                    ^^ source.vehicle constant.numeric.integral.decimal.vehicle
-#                      ^^ source.vehicle
-#                        ^^ source.vehicle constant.numeric.integral.decimal.vehicle
-#                          ^^ source.vehicle
-#                            ^^ source.vehicle keyword.operator.arrow.vehicle
-#                              ^ source.vehicle
-#                               ^^^^^^ source.vehicle support.type.vector.vehicle
-#                                     ^ source.vehicle
-#                                      ^^^ source.vehicle support.type.rat.vehicle
-#                                         ^ source.vehicle
-#                                          ^^ source.vehicle constant.numeric.integral.decimal.vehicle
+#               ^^^^ source.vehicle support.type.rat.vehicle
+#                   ^^ source.vehicle
+#                     ^^ source.vehicle constant.numeric.integral.decimal.vehicle
+#                       ^^ source.vehicle
+#                         ^^ source.vehicle constant.numeric.integral.decimal.vehicle
+#                           ^^ source.vehicle
+#                             ^^ source.vehicle keyword.operator.arrow.vehicle
+#                               ^ source.vehicle
+#                                ^^^^^^ source.vehicle support.type.vector.vehicle
+#                                      ^ source.vehicle
+#                                       ^^^^ source.vehicle support.type.rat.vehicle
+#                                           ^ source.vehicle
+#                                            ^^ source.vehicle constant.numeric.integral.decimal.vehicle
 >
 >--------------------------------------------------------------------------------
 #^^ source.vehicle comment.line.double-dash.vehicle punctuation.definition.comment.vehicle
@@ -67,16 +67,16 @@
 #^^ source.vehicle comment.line.double-dash.vehicle punctuation.definition.comment.vehicle
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.vehicle comment.line.double-dash.vehicle
 >
->--epsilon : Rat
+>--epsilon : Real
 #^^ source.vehicle comment.line.double-dash.vehicle punctuation.definition.comment.vehicle
-#  ^^^^^^^^^^^^^ source.vehicle comment.line.double-dash.vehicle
+#  ^^^^^^^^^^^^^^ source.vehicle comment.line.double-dash.vehicle
 >--epsilon = 0.01
 #^^ source.vehicle comment.line.double-dash.vehicle punctuation.definition.comment.vehicle
 #  ^^^^^^^^^^^^^^ source.vehicle comment.line.double-dash.vehicle
 >
->--delta : Rat
+>--delta : Real
 #^^ source.vehicle comment.line.double-dash.vehicle punctuation.definition.comment.vehicle
-#  ^^^^^^^^^^^ source.vehicle comment.line.double-dash.vehicle
+#  ^^^^^^^^^^^^ source.vehicle comment.line.double-dash.vehicle
 >--delta = 0.02
 #^^ source.vehicle comment.line.double-dash.vehicle punctuation.definition.comment.vehicle
 #  ^^^^^^^^^^^^ source.vehicle comment.line.double-dash.vehicle
@@ -87,21 +87,21 @@
 >-- size epsilon around 0.
 #^^ source.vehicle comment.line.double-dash.vehicle punctuation.definition.comment.vehicle
 #  ^^^^^^^^^^^^^^^^^^^^^^^ source.vehicle comment.line.double-dash.vehicle
->boundedByEpsilon : Tensor Rat [28, 28] -> Bool
+>boundedByEpsilon : Tensor Real [28, 28] -> Bool
 #^^^^^^^^^^^^^^^^^ source.vehicle
 #                 ^ source.vehicle keyword.operator.colon.vehicle
 #                  ^ source.vehicle
 #                   ^^^^^^ source.vehicle support.type.tensor.vehicle
 #                         ^ source.vehicle
-#                          ^^^ source.vehicle support.type.rat.vehicle
-#                             ^^ source.vehicle
-#                               ^^ source.vehicle constant.numeric.integral.decimal.vehicle
-#                                 ^^ source.vehicle
-#                                   ^^ source.vehicle constant.numeric.integral.decimal.vehicle
-#                                     ^^ source.vehicle
-#                                       ^^ source.vehicle keyword.operator.arrow.vehicle
-#                                         ^ source.vehicle
-#                                          ^^^^ source.vehicle support.type.bool.vehicle
+#                          ^^^^ source.vehicle support.type.rat.vehicle
+#                              ^^ source.vehicle
+#                                ^^ source.vehicle constant.numeric.integral.decimal.vehicle
+#                                  ^^ source.vehicle
+#                                    ^^ source.vehicle constant.numeric.integral.decimal.vehicle
+#                                      ^^ source.vehicle
+#                                        ^^ source.vehicle keyword.operator.arrow.vehicle
+#                                          ^ source.vehicle
+#                                           ^^^^ source.vehicle support.type.bool.vehicle
 >boundedByEpsilon x = forall i j . -0.01 <= x ! i ! j <= 0.01
 #^^^^^^^^^^^^^^^^^^^ source.vehicle
 #                   ^ source.vehicle keyword.operator.define.vehicle
@@ -126,31 +126,31 @@
 >--The disjunction avoids having to define absolute value
 #^^ source.vehicle comment.line.double-dash.vehicle punctuation.definition.comment.vehicle
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.vehicle comment.line.double-dash.vehicle
->boundedByDelta : Tensor Rat [28, 28] -> Tensor Rat [28, 28] -> Bool
+>boundedByDelta : Tensor Real [28, 28] -> Tensor Real [28, 28] -> Bool
 #^^^^^^^^^^^^^^^ source.vehicle
 #               ^ source.vehicle keyword.operator.colon.vehicle
 #                ^ source.vehicle
 #                 ^^^^^^ source.vehicle support.type.tensor.vehicle
 #                       ^ source.vehicle
-#                        ^^^ source.vehicle support.type.rat.vehicle
-#                           ^^ source.vehicle
-#                             ^^ source.vehicle constant.numeric.integral.decimal.vehicle
-#                               ^^ source.vehicle
-#                                 ^^ source.vehicle constant.numeric.integral.decimal.vehicle
-#                                   ^^ source.vehicle
-#                                     ^^ source.vehicle keyword.operator.arrow.vehicle
-#                                       ^ source.vehicle
-#                                        ^^^^^^ source.vehicle support.type.tensor.vehicle
-#                                              ^ source.vehicle
-#                                               ^^^ source.vehicle support.type.rat.vehicle
-#                                                  ^^ source.vehicle
-#                                                    ^^ source.vehicle constant.numeric.integral.decimal.vehicle
-#                                                      ^^ source.vehicle
-#                                                        ^^ source.vehicle constant.numeric.integral.decimal.vehicle
-#                                                          ^^ source.vehicle
-#                                                            ^^ source.vehicle keyword.operator.arrow.vehicle
-#                                                              ^ source.vehicle
-#                                                               ^^^^ source.vehicle support.type.bool.vehicle
+#                        ^^^^ source.vehicle support.type.rat.vehicle
+#                            ^^ source.vehicle
+#                              ^^ source.vehicle constant.numeric.integral.decimal.vehicle
+#                                ^^ source.vehicle
+#                                  ^^ source.vehicle constant.numeric.integral.decimal.vehicle
+#                                    ^^ source.vehicle
+#                                      ^^ source.vehicle keyword.operator.arrow.vehicle
+#                                        ^ source.vehicle
+#                                         ^^^^^^ source.vehicle support.type.tensor.vehicle
+#                                               ^ source.vehicle
+#                                                ^^^^ source.vehicle support.type.rat.vehicle
+#                                                    ^^ source.vehicle
+#                                                      ^^ source.vehicle constant.numeric.integral.decimal.vehicle
+#                                                        ^^ source.vehicle
+#                                                          ^^ source.vehicle constant.numeric.integral.decimal.vehicle
+#                                                            ^^ source.vehicle
+#                                                              ^^ source.vehicle keyword.operator.arrow.vehicle
+#                                                                ^ source.vehicle
+#                                                                 ^^^^ source.vehicle support.type.bool.vehicle
 >boundedByDelta x y = forall k . (-0.02 <= (((mnist x) ! k ) - ((mnist y) ! k )) <= 0.02)
 #^^^^^^^^^^^^^^^^^^^ source.vehicle
 #                   ^ source.vehicle keyword.operator.define.vehicle
@@ -175,21 +175,21 @@
 #                                                                                       ^^ source.vehicle
 >
 >
->robustSingleInput : Tensor Rat [28, 28] -> Bool
+>robustSingleInput : Tensor Real [28, 28] -> Bool
 #^^^^^^^^^^^^^^^^^^ source.vehicle
 #                  ^ source.vehicle keyword.operator.colon.vehicle
 #                   ^ source.vehicle
 #                    ^^^^^^ source.vehicle support.type.tensor.vehicle
 #                          ^ source.vehicle
-#                           ^^^ source.vehicle support.type.rat.vehicle
-#                              ^^ source.vehicle
-#                                ^^ source.vehicle constant.numeric.integral.decimal.vehicle
-#                                  ^^ source.vehicle
-#                                    ^^ source.vehicle constant.numeric.integral.decimal.vehicle
-#                                      ^^ source.vehicle
-#                                        ^^ source.vehicle keyword.operator.arrow.vehicle
-#                                          ^ source.vehicle
-#                                           ^^^^ source.vehicle support.type.bool.vehicle
+#                           ^^^^ source.vehicle support.type.rat.vehicle
+#                               ^^ source.vehicle
+#                                 ^^ source.vehicle constant.numeric.integral.decimal.vehicle
+#                                   ^^ source.vehicle
+#                                     ^^ source.vehicle constant.numeric.integral.decimal.vehicle
+#                                       ^^ source.vehicle
+#                                         ^^ source.vehicle keyword.operator.arrow.vehicle
+#                                           ^ source.vehicle
+#                                            ^^^^ source.vehicle support.type.bool.vehicle
 >robustSingleInput image = forall pertubation .
 #^^^^^^^^^^^^^^^^^^^^^^^^ source.vehicle
 #                        ^ source.vehicle keyword.operator.define.vehicle

--- a/tests/snap/nonLinearIfCondition.vcl
+++ b/tests/snap/nonLinearIfCondition.vcl
@@ -1,6 +1,6 @@
 @network
-f : Vector Rat 1 -> Vector Rat 1
+f : Vector Real 1 -> Vector Real 1
 
 @property
 p : Bool
-p = forall (x : Rat) . (if x * x > 0 then True else False)
+p = forall (x : Real) . (if x * x > 0 then True else False)

--- a/tests/snap/nonLinearIfCondition.vcl.snap
+++ b/tests/snap/nonLinearIfCondition.vcl.snap
@@ -1,22 +1,22 @@
 >@network
 #^^^^^^^^ source.vehicle keyword.other.declaration.network.vehicle
->f : Vector Rat 1 -> Vector Rat 1
+>f : Vector Real 1 -> Vector Real 1
 #^^ source.vehicle
 #  ^ source.vehicle keyword.operator.colon.vehicle
 #   ^ source.vehicle
 #    ^^^^^^ source.vehicle support.type.vector.vehicle
 #          ^ source.vehicle
-#           ^^^ source.vehicle support.type.rat.vehicle
-#              ^ source.vehicle
-#               ^ source.vehicle constant.numeric.integral.decimal.vehicle
-#                ^ source.vehicle
-#                 ^^ source.vehicle keyword.operator.arrow.vehicle
-#                   ^ source.vehicle
-#                    ^^^^^^ source.vehicle support.type.vector.vehicle
-#                          ^ source.vehicle
-#                           ^^^ source.vehicle support.type.rat.vehicle
-#                              ^ source.vehicle
-#                               ^ source.vehicle constant.numeric.integral.decimal.vehicle
+#           ^^^^ source.vehicle support.type.rat.vehicle
+#               ^ source.vehicle
+#                ^ source.vehicle constant.numeric.integral.decimal.vehicle
+#                 ^ source.vehicle
+#                  ^^ source.vehicle keyword.operator.arrow.vehicle
+#                    ^ source.vehicle
+#                     ^^^^^^ source.vehicle support.type.vector.vehicle
+#                           ^ source.vehicle
+#                            ^^^^ source.vehicle support.type.rat.vehicle
+#                                ^ source.vehicle
+#                                 ^ source.vehicle constant.numeric.integral.decimal.vehicle
 >
 >@property
 #^^^^^^^^^ source.vehicle keyword.other.declaration.property.vehicle
@@ -25,7 +25,7 @@
 #  ^ source.vehicle keyword.operator.colon.vehicle
 #   ^ source.vehicle
 #    ^^^^ source.vehicle support.type.bool.vehicle
->p = forall (x : Rat) . (if x * x > 0 then True else False)
+>p = forall (x : Real) . (if x * x > 0 then True else False)
 #^^ source.vehicle
 #  ^ source.vehicle keyword.operator.define.vehicle
 #   ^ source.vehicle
@@ -33,24 +33,24 @@
 #          ^^^^ source.vehicle
 #              ^ source.vehicle keyword.operator.colon.vehicle
 #               ^ source.vehicle
-#                ^^^ source.vehicle support.type.rat.vehicle
-#                   ^^ source.vehicle
-#                     ^ source.vehicle keyword.operator.dot.vehicle
-#                      ^^ source.vehicle
-#                        ^^ source.vehicle keyword.control.if.vehicle
-#                          ^^^ source.vehicle
-#                             ^ source.vehicle keyword.operator.mul.vehicle
-#                              ^^^ source.vehicle
-#                                 ^ source.vehicle keyword.operator.gt.vehicle
-#                                  ^ source.vehicle
-#                                   ^ source.vehicle constant.numeric.integral.decimal.vehicle
-#                                    ^ source.vehicle
-#                                     ^^^^ source.vehicle keyword.control.then.vehicle
-#                                         ^ source.vehicle
-#                                          ^^^^ source.vehicle constant.language.true.vehicle
-#                                              ^ source.vehicle
-#                                               ^^^^ source.vehicle keyword.control.else.vehicle
-#                                                   ^ source.vehicle
-#                                                    ^^^^^ source.vehicle constant.language.false.vehicle
-#                                                         ^^ source.vehicle
+#                ^^^^ source.vehicle support.type.rat.vehicle
+#                    ^^ source.vehicle
+#                      ^ source.vehicle keyword.operator.dot.vehicle
+#                       ^^ source.vehicle
+#                         ^^ source.vehicle keyword.control.if.vehicle
+#                           ^^^ source.vehicle
+#                              ^ source.vehicle keyword.operator.mul.vehicle
+#                               ^^^ source.vehicle
+#                                  ^ source.vehicle keyword.operator.gt.vehicle
+#                                   ^ source.vehicle
+#                                    ^ source.vehicle constant.numeric.integral.decimal.vehicle
+#                                     ^ source.vehicle
+#                                      ^^^^ source.vehicle keyword.control.then.vehicle
+#                                          ^ source.vehicle
+#                                           ^^^^ source.vehicle constant.language.true.vehicle
+#                                               ^ source.vehicle
+#                                                ^^^^ source.vehicle keyword.control.else.vehicle
+#                                                    ^ source.vehicle
+#                                                     ^^^^^ source.vehicle constant.language.false.vehicle
+#                                                          ^^ source.vehicle
 >

--- a/tests/snap/notAFunction.vcl
+++ b/tests/snap/notAFunction.vcl
@@ -1,2 +1,2 @@
 @network
-f : Rat
+f : Real

--- a/tests/snap/notAFunction.vcl.snap
+++ b/tests/snap/notAFunction.vcl.snap
@@ -1,8 +1,8 @@
 >@network
 #^^^^^^^^ source.vehicle keyword.other.declaration.network.vehicle
->f : Rat
+>f : Real
 #^^ source.vehicle
 #  ^ source.vehicle keyword.operator.colon.vehicle
 #   ^ source.vehicle
-#    ^^^ source.vehicle support.type.rat.vehicle
+#    ^^^^ source.vehicle support.type.rat.vehicle
 >

--- a/tests/snap/quadraticFunInput.vcl
+++ b/tests/snap/quadraticFunInput.vcl
@@ -1,9 +1,9 @@
 @network
-f : Vector Rat 1 -> Vector Rat 1
+f : Vector Real 1 -> Vector Real 1
 
-square : Rat -> Rat
+square : Real -> Real
 square y = y * y
 
 @property
 p : Bool
-p = forall (x : Rat) . f [square x] ! 0 > 0
+p = forall (x : Real) . f [square x] ! 0 > 0

--- a/tests/snap/quadraticFunInput.vcl.snap
+++ b/tests/snap/quadraticFunInput.vcl.snap
@@ -1,32 +1,32 @@
 >@network
 #^^^^^^^^ source.vehicle keyword.other.declaration.network.vehicle
->f : Vector Rat 1 -> Vector Rat 1
+>f : Vector Real 1 -> Vector Real 1
 #^^ source.vehicle
 #  ^ source.vehicle keyword.operator.colon.vehicle
 #   ^ source.vehicle
 #    ^^^^^^ source.vehicle support.type.vector.vehicle
 #          ^ source.vehicle
-#           ^^^ source.vehicle support.type.rat.vehicle
-#              ^ source.vehicle
-#               ^ source.vehicle constant.numeric.integral.decimal.vehicle
-#                ^ source.vehicle
-#                 ^^ source.vehicle keyword.operator.arrow.vehicle
-#                   ^ source.vehicle
-#                    ^^^^^^ source.vehicle support.type.vector.vehicle
-#                          ^ source.vehicle
-#                           ^^^ source.vehicle support.type.rat.vehicle
-#                              ^ source.vehicle
-#                               ^ source.vehicle constant.numeric.integral.decimal.vehicle
+#           ^^^^ source.vehicle support.type.rat.vehicle
+#               ^ source.vehicle
+#                ^ source.vehicle constant.numeric.integral.decimal.vehicle
+#                 ^ source.vehicle
+#                  ^^ source.vehicle keyword.operator.arrow.vehicle
+#                    ^ source.vehicle
+#                     ^^^^^^ source.vehicle support.type.vector.vehicle
+#                           ^ source.vehicle
+#                            ^^^^ source.vehicle support.type.rat.vehicle
+#                                ^ source.vehicle
+#                                 ^ source.vehicle constant.numeric.integral.decimal.vehicle
 >
->square : Rat -> Rat
+>square : Real -> Real
 #^^^^^^^ source.vehicle
 #       ^ source.vehicle keyword.operator.colon.vehicle
 #        ^ source.vehicle
-#         ^^^ source.vehicle support.type.rat.vehicle
-#            ^ source.vehicle
-#             ^^ source.vehicle keyword.operator.arrow.vehicle
-#               ^ source.vehicle
-#                ^^^ source.vehicle support.type.rat.vehicle
+#         ^^^^ source.vehicle support.type.rat.vehicle
+#             ^ source.vehicle
+#              ^^ source.vehicle keyword.operator.arrow.vehicle
+#                ^ source.vehicle
+#                 ^^^^ source.vehicle support.type.rat.vehicle
 >square y = y * y
 #^^^^^^^^^ source.vehicle
 #         ^ source.vehicle keyword.operator.define.vehicle
@@ -41,7 +41,7 @@
 #  ^ source.vehicle keyword.operator.colon.vehicle
 #   ^ source.vehicle
 #    ^^^^ source.vehicle support.type.bool.vehicle
->p = forall (x : Rat) . f [square x] ! 0 > 0
+>p = forall (x : Real) . f [square x] ! 0 > 0
 #^^ source.vehicle
 #  ^ source.vehicle keyword.operator.define.vehicle
 #   ^ source.vehicle
@@ -49,15 +49,15 @@
 #          ^^^^ source.vehicle
 #              ^ source.vehicle keyword.operator.colon.vehicle
 #               ^ source.vehicle
-#                ^^^ source.vehicle support.type.rat.vehicle
-#                   ^^ source.vehicle
-#                     ^ source.vehicle keyword.operator.dot.vehicle
-#                      ^^^^^^^^^^^^^^ source.vehicle
-#                                    ^ source.vehicle keyword.operator.lookup.vehicle
-#                                     ^ source.vehicle
-#                                      ^ source.vehicle constant.numeric.integral.decimal.vehicle
-#                                       ^ source.vehicle
-#                                        ^ source.vehicle keyword.operator.gt.vehicle
-#                                         ^ source.vehicle
-#                                          ^ source.vehicle constant.numeric.integral.decimal.vehicle
+#                ^^^^ source.vehicle support.type.rat.vehicle
+#                    ^^ source.vehicle
+#                      ^ source.vehicle keyword.operator.dot.vehicle
+#                       ^^^^^^^^^^^^^^ source.vehicle
+#                                     ^ source.vehicle keyword.operator.lookup.vehicle
+#                                      ^ source.vehicle
+#                                       ^ source.vehicle constant.numeric.integral.decimal.vehicle
+#                                        ^ source.vehicle
+#                                         ^ source.vehicle keyword.operator.gt.vehicle
+#                                          ^ source.vehicle
+#                                           ^ source.vehicle constant.numeric.integral.decimal.vehicle
 >

--- a/tests/snap/quadraticFunOutput.vcl
+++ b/tests/snap/quadraticFunOutput.vcl
@@ -1,9 +1,9 @@
 @network
-f : Vector Rat 1 -> Vector Rat 1
+f : Vector Real 1 -> Vector Real 1
 
-square : Rat -> Rat
+square : Real -> Real
 square y = y * y
 
 @property
 p : Bool
-p = forall (x : Rat) . square (f [x] ! 0) > 0
+p = forall (x : Real) . square (f [x] ! 0) > 0

--- a/tests/snap/quadraticFunOutput.vcl.snap
+++ b/tests/snap/quadraticFunOutput.vcl.snap
@@ -1,32 +1,32 @@
 >@network
 #^^^^^^^^ source.vehicle keyword.other.declaration.network.vehicle
->f : Vector Rat 1 -> Vector Rat 1
+>f : Vector Real 1 -> Vector Real 1
 #^^ source.vehicle
 #  ^ source.vehicle keyword.operator.colon.vehicle
 #   ^ source.vehicle
 #    ^^^^^^ source.vehicle support.type.vector.vehicle
 #          ^ source.vehicle
-#           ^^^ source.vehicle support.type.rat.vehicle
-#              ^ source.vehicle
-#               ^ source.vehicle constant.numeric.integral.decimal.vehicle
-#                ^ source.vehicle
-#                 ^^ source.vehicle keyword.operator.arrow.vehicle
-#                   ^ source.vehicle
-#                    ^^^^^^ source.vehicle support.type.vector.vehicle
-#                          ^ source.vehicle
-#                           ^^^ source.vehicle support.type.rat.vehicle
-#                              ^ source.vehicle
-#                               ^ source.vehicle constant.numeric.integral.decimal.vehicle
+#           ^^^^ source.vehicle support.type.rat.vehicle
+#               ^ source.vehicle
+#                ^ source.vehicle constant.numeric.integral.decimal.vehicle
+#                 ^ source.vehicle
+#                  ^^ source.vehicle keyword.operator.arrow.vehicle
+#                    ^ source.vehicle
+#                     ^^^^^^ source.vehicle support.type.vector.vehicle
+#                           ^ source.vehicle
+#                            ^^^^ source.vehicle support.type.rat.vehicle
+#                                ^ source.vehicle
+#                                 ^ source.vehicle constant.numeric.integral.decimal.vehicle
 >
->square : Rat -> Rat
+>square : Real -> Real
 #^^^^^^^ source.vehicle
 #       ^ source.vehicle keyword.operator.colon.vehicle
 #        ^ source.vehicle
-#         ^^^ source.vehicle support.type.rat.vehicle
-#            ^ source.vehicle
-#             ^^ source.vehicle keyword.operator.arrow.vehicle
-#               ^ source.vehicle
-#                ^^^ source.vehicle support.type.rat.vehicle
+#         ^^^^ source.vehicle support.type.rat.vehicle
+#             ^ source.vehicle
+#              ^^ source.vehicle keyword.operator.arrow.vehicle
+#                ^ source.vehicle
+#                 ^^^^ source.vehicle support.type.rat.vehicle
 >square y = y * y
 #^^^^^^^^^ source.vehicle
 #         ^ source.vehicle keyword.operator.define.vehicle
@@ -41,7 +41,7 @@
 #  ^ source.vehicle keyword.operator.colon.vehicle
 #   ^ source.vehicle
 #    ^^^^ source.vehicle support.type.bool.vehicle
->p = forall (x : Rat) . square (f [x] ! 0) > 0
+>p = forall (x : Real) . square (f [x] ! 0) > 0
 #^^ source.vehicle
 #  ^ source.vehicle keyword.operator.define.vehicle
 #   ^ source.vehicle
@@ -49,15 +49,15 @@
 #          ^^^^ source.vehicle
 #              ^ source.vehicle keyword.operator.colon.vehicle
 #               ^ source.vehicle
-#                ^^^ source.vehicle support.type.rat.vehicle
-#                   ^^ source.vehicle
-#                     ^ source.vehicle keyword.operator.dot.vehicle
-#                      ^^^^^^^^^^^^^^^ source.vehicle
-#                                     ^ source.vehicle keyword.operator.lookup.vehicle
-#                                      ^ source.vehicle
-#                                       ^ source.vehicle constant.numeric.integral.decimal.vehicle
-#                                        ^^ source.vehicle
-#                                          ^ source.vehicle keyword.operator.gt.vehicle
-#                                           ^ source.vehicle
-#                                            ^ source.vehicle constant.numeric.integral.decimal.vehicle
+#                ^^^^ source.vehicle support.type.rat.vehicle
+#                    ^^ source.vehicle
+#                      ^ source.vehicle keyword.operator.dot.vehicle
+#                       ^^^^^^^^^^^^^^^ source.vehicle
+#                                      ^ source.vehicle keyword.operator.lookup.vehicle
+#                                       ^ source.vehicle
+#                                        ^ source.vehicle constant.numeric.integral.decimal.vehicle
+#                                         ^^ source.vehicle
+#                                           ^ source.vehicle keyword.operator.gt.vehicle
+#                                            ^ source.vehicle
+#                                             ^ source.vehicle constant.numeric.integral.decimal.vehicle
 >

--- a/tests/snap/quadraticInput.vcl
+++ b/tests/snap/quadraticInput.vcl
@@ -1,6 +1,6 @@
 @network
-f : Vector Rat 1 -> Vector Rat 1
+f : Vector Real 1 -> Vector Real 1
 
 @property
 p : Bool
-p = forall (x : Rat) . f [x * x] ! 0 > 0
+p = forall (x : Real) . f [x * x] ! 0 > 0

--- a/tests/snap/quadraticInput.vcl.snap
+++ b/tests/snap/quadraticInput.vcl.snap
@@ -1,22 +1,22 @@
 >@network
 #^^^^^^^^ source.vehicle keyword.other.declaration.network.vehicle
->f : Vector Rat 1 -> Vector Rat 1
+>f : Vector Real 1 -> Vector Real 1
 #^^ source.vehicle
 #  ^ source.vehicle keyword.operator.colon.vehicle
 #   ^ source.vehicle
 #    ^^^^^^ source.vehicle support.type.vector.vehicle
 #          ^ source.vehicle
-#           ^^^ source.vehicle support.type.rat.vehicle
-#              ^ source.vehicle
-#               ^ source.vehicle constant.numeric.integral.decimal.vehicle
-#                ^ source.vehicle
-#                 ^^ source.vehicle keyword.operator.arrow.vehicle
-#                   ^ source.vehicle
-#                    ^^^^^^ source.vehicle support.type.vector.vehicle
-#                          ^ source.vehicle
-#                           ^^^ source.vehicle support.type.rat.vehicle
-#                              ^ source.vehicle
-#                               ^ source.vehicle constant.numeric.integral.decimal.vehicle
+#           ^^^^ source.vehicle support.type.rat.vehicle
+#               ^ source.vehicle
+#                ^ source.vehicle constant.numeric.integral.decimal.vehicle
+#                 ^ source.vehicle
+#                  ^^ source.vehicle keyword.operator.arrow.vehicle
+#                    ^ source.vehicle
+#                     ^^^^^^ source.vehicle support.type.vector.vehicle
+#                           ^ source.vehicle
+#                            ^^^^ source.vehicle support.type.rat.vehicle
+#                                ^ source.vehicle
+#                                 ^ source.vehicle constant.numeric.integral.decimal.vehicle
 >
 >@property
 #^^^^^^^^^ source.vehicle keyword.other.declaration.property.vehicle
@@ -25,7 +25,7 @@
 #  ^ source.vehicle keyword.operator.colon.vehicle
 #   ^ source.vehicle
 #    ^^^^ source.vehicle support.type.bool.vehicle
->p = forall (x : Rat) . f [x * x] ! 0 > 0
+>p = forall (x : Real) . f [x * x] ! 0 > 0
 #^^ source.vehicle
 #  ^ source.vehicle keyword.operator.define.vehicle
 #   ^ source.vehicle
@@ -33,17 +33,17 @@
 #          ^^^^ source.vehicle
 #              ^ source.vehicle keyword.operator.colon.vehicle
 #               ^ source.vehicle
-#                ^^^ source.vehicle support.type.rat.vehicle
-#                   ^^ source.vehicle
-#                     ^ source.vehicle keyword.operator.dot.vehicle
-#                      ^^^^^^ source.vehicle
-#                            ^ source.vehicle keyword.operator.mul.vehicle
-#                             ^^^^ source.vehicle
-#                                 ^ source.vehicle keyword.operator.lookup.vehicle
-#                                  ^ source.vehicle
-#                                   ^ source.vehicle constant.numeric.integral.decimal.vehicle
-#                                    ^ source.vehicle
-#                                     ^ source.vehicle keyword.operator.gt.vehicle
-#                                      ^ source.vehicle
-#                                       ^ source.vehicle constant.numeric.integral.decimal.vehicle
+#                ^^^^ source.vehicle support.type.rat.vehicle
+#                    ^^ source.vehicle
+#                      ^ source.vehicle keyword.operator.dot.vehicle
+#                       ^^^^^^ source.vehicle
+#                             ^ source.vehicle keyword.operator.mul.vehicle
+#                              ^^^^ source.vehicle
+#                                  ^ source.vehicle keyword.operator.lookup.vehicle
+#                                   ^ source.vehicle
+#                                    ^ source.vehicle constant.numeric.integral.decimal.vehicle
+#                                     ^ source.vehicle
+#                                      ^ source.vehicle keyword.operator.gt.vehicle
+#                                       ^ source.vehicle
+#                                        ^ source.vehicle constant.numeric.integral.decimal.vehicle
 >

--- a/tests/snap/quadraticInputOutput.vcl
+++ b/tests/snap/quadraticInputOutput.vcl
@@ -1,6 +1,6 @@
 @network
-f : Vector Rat 1 -> Vector Rat 1
+f : Vector Real 1 -> Vector Real 1
 
 @property
 p : Bool
-p = forall (x : Rat) . (f [x] ! 0) * x > 0
+p = forall (x : Real) . (f [x] ! 0) * x > 0

--- a/tests/snap/quadraticInputOutput.vcl.snap
+++ b/tests/snap/quadraticInputOutput.vcl.snap
@@ -1,22 +1,22 @@
 >@network
 #^^^^^^^^ source.vehicle keyword.other.declaration.network.vehicle
->f : Vector Rat 1 -> Vector Rat 1
+>f : Vector Real 1 -> Vector Real 1
 #^^ source.vehicle
 #  ^ source.vehicle keyword.operator.colon.vehicle
 #   ^ source.vehicle
 #    ^^^^^^ source.vehicle support.type.vector.vehicle
 #          ^ source.vehicle
-#           ^^^ source.vehicle support.type.rat.vehicle
-#              ^ source.vehicle
-#               ^ source.vehicle constant.numeric.integral.decimal.vehicle
-#                ^ source.vehicle
-#                 ^^ source.vehicle keyword.operator.arrow.vehicle
-#                   ^ source.vehicle
-#                    ^^^^^^ source.vehicle support.type.vector.vehicle
-#                          ^ source.vehicle
-#                           ^^^ source.vehicle support.type.rat.vehicle
-#                              ^ source.vehicle
-#                               ^ source.vehicle constant.numeric.integral.decimal.vehicle
+#           ^^^^ source.vehicle support.type.rat.vehicle
+#               ^ source.vehicle
+#                ^ source.vehicle constant.numeric.integral.decimal.vehicle
+#                 ^ source.vehicle
+#                  ^^ source.vehicle keyword.operator.arrow.vehicle
+#                    ^ source.vehicle
+#                     ^^^^^^ source.vehicle support.type.vector.vehicle
+#                           ^ source.vehicle
+#                            ^^^^ source.vehicle support.type.rat.vehicle
+#                                ^ source.vehicle
+#                                 ^ source.vehicle constant.numeric.integral.decimal.vehicle
 >
 >@property
 #^^^^^^^^^ source.vehicle keyword.other.declaration.property.vehicle
@@ -25,7 +25,7 @@
 #  ^ source.vehicle keyword.operator.colon.vehicle
 #   ^ source.vehicle
 #    ^^^^ source.vehicle support.type.bool.vehicle
->p = forall (x : Rat) . (f [x] ! 0) * x > 0
+>p = forall (x : Real) . (f [x] ! 0) * x > 0
 #^^ source.vehicle
 #  ^ source.vehicle keyword.operator.define.vehicle
 #   ^ source.vehicle
@@ -33,17 +33,17 @@
 #          ^^^^ source.vehicle
 #              ^ source.vehicle keyword.operator.colon.vehicle
 #               ^ source.vehicle
-#                ^^^ source.vehicle support.type.rat.vehicle
-#                   ^^ source.vehicle
-#                     ^ source.vehicle keyword.operator.dot.vehicle
-#                      ^^^^^^^^ source.vehicle
-#                              ^ source.vehicle keyword.operator.lookup.vehicle
-#                               ^ source.vehicle
-#                                ^ source.vehicle constant.numeric.integral.decimal.vehicle
-#                                 ^^ source.vehicle
-#                                   ^ source.vehicle keyword.operator.mul.vehicle
-#                                    ^^^ source.vehicle
-#                                       ^ source.vehicle keyword.operator.gt.vehicle
-#                                        ^ source.vehicle
-#                                         ^ source.vehicle constant.numeric.integral.decimal.vehicle
+#                ^^^^ source.vehicle support.type.rat.vehicle
+#                    ^^ source.vehicle
+#                      ^ source.vehicle keyword.operator.dot.vehicle
+#                       ^^^^^^^^ source.vehicle
+#                               ^ source.vehicle keyword.operator.lookup.vehicle
+#                                ^ source.vehicle
+#                                 ^ source.vehicle constant.numeric.integral.decimal.vehicle
+#                                  ^^ source.vehicle
+#                                    ^ source.vehicle keyword.operator.mul.vehicle
+#                                     ^^^ source.vehicle
+#                                        ^ source.vehicle keyword.operator.gt.vehicle
+#                                         ^ source.vehicle
+#                                          ^ source.vehicle constant.numeric.integral.decimal.vehicle
 >

--- a/tests/snap/quadraticTensorInputLookup.vcl
+++ b/tests/snap/quadraticTensorInputLookup.vcl
@@ -1,5 +1,5 @@
 @network
-f : Vector Rat 1 -> Vector Rat 1
+f : Vector Real 1 -> Vector Real 1
 
 @property
 p : Bool

--- a/tests/snap/quadraticTensorInputLookup.vcl.snap
+++ b/tests/snap/quadraticTensorInputLookup.vcl.snap
@@ -1,22 +1,22 @@
 >@network
 #^^^^^^^^ source.vehicle keyword.other.declaration.network.vehicle
->f : Vector Rat 1 -> Vector Rat 1
+>f : Vector Real 1 -> Vector Real 1
 #^^ source.vehicle
 #  ^ source.vehicle keyword.operator.colon.vehicle
 #   ^ source.vehicle
 #    ^^^^^^ source.vehicle support.type.vector.vehicle
 #          ^ source.vehicle
-#           ^^^ source.vehicle support.type.rat.vehicle
-#              ^ source.vehicle
-#               ^ source.vehicle constant.numeric.integral.decimal.vehicle
-#                ^ source.vehicle
-#                 ^^ source.vehicle keyword.operator.arrow.vehicle
-#                   ^ source.vehicle
-#                    ^^^^^^ source.vehicle support.type.vector.vehicle
-#                          ^ source.vehicle
-#                           ^^^ source.vehicle support.type.rat.vehicle
-#                              ^ source.vehicle
-#                               ^ source.vehicle constant.numeric.integral.decimal.vehicle
+#           ^^^^ source.vehicle support.type.rat.vehicle
+#               ^ source.vehicle
+#                ^ source.vehicle constant.numeric.integral.decimal.vehicle
+#                 ^ source.vehicle
+#                  ^^ source.vehicle keyword.operator.arrow.vehicle
+#                    ^ source.vehicle
+#                     ^^^^^^ source.vehicle support.type.vector.vehicle
+#                           ^ source.vehicle
+#                            ^^^^ source.vehicle support.type.rat.vehicle
+#                                ^ source.vehicle
+#                                 ^ source.vehicle constant.numeric.integral.decimal.vehicle
 >
 >@property
 #^^^^^^^^^ source.vehicle keyword.other.declaration.property.vehicle

--- a/tests/snap/record.vcl
+++ b/tests/snap/record.vcl
@@ -11,3 +11,9 @@ record HasComparison t1 t2 where
   , neTC : t1 -> t2 -> Bool
   }
 
+@tensor
+record Pair where
+  { a : Real
+  , b : Real
+  } supports Addition
+

--- a/tests/snap/record.vcl
+++ b/tests/snap/record.vcl
@@ -1,0 +1,13 @@
+@typeclass
+record HasValidNetworkType (t : Type) where {}
+
+@typeclass
+record HasComparison t1 t2 where
+  { leTC : t1 -> t2 -> Bool
+  , ltTC : t1 -> t2 -> Bool
+  , geTC : t1 -> t2 -> Bool
+  , gtTC : t1 -> t2 -> Bool
+  , eqTC : t1 -> t2 -> Bool
+  , neTC : t1 -> t2 -> Bool
+  }
+

--- a/tests/snap/record.vcl.snap
+++ b/tests/snap/record.vcl.snap
@@ -1,0 +1,76 @@
+>@typeclass
+#^^^^^^^^^^ source.vehicle keyword.other.declaration.typeclass.vehicle
+>record HasValidNetworkType (t : Type) where {}
+#^^^^^^ source.vehicle keyword.other.declaration.record.vehicle
+#      ^^^^^^^^^^^^^^^^^^^^^^^^ source.vehicle
+#                              ^ source.vehicle keyword.operator.colon.vehicle
+#                               ^ source.vehicle
+#                                ^^^^ source.vehicle support.type.type.vehicle
+#                                    ^^ source.vehicle
+#                                      ^^^^^ source.vehicle keyword.other.declaration.where.vehicle
+#                                           ^^^^ source.vehicle
+>
+>@typeclass
+#^^^^^^^^^^ source.vehicle keyword.other.declaration.typeclass.vehicle
+>record HasComparison t1 t2 where
+#^^^^^^ source.vehicle keyword.other.declaration.record.vehicle
+#      ^^^^^^^^^^^^^^^^^^^^^ source.vehicle
+#                           ^^^^^ source.vehicle keyword.other.declaration.where.vehicle
+>  { leTC : t1 -> t2 -> Bool
+#^^^^^^^^^ source.vehicle
+#         ^ source.vehicle keyword.operator.colon.vehicle
+#          ^^^^ source.vehicle
+#              ^^ source.vehicle keyword.operator.arrow.vehicle
+#                ^^^^ source.vehicle
+#                    ^^ source.vehicle keyword.operator.arrow.vehicle
+#                      ^ source.vehicle
+#                       ^^^^ source.vehicle support.type.bool.vehicle
+>  , ltTC : t1 -> t2 -> Bool
+#^^^^^^^^^ source.vehicle
+#         ^ source.vehicle keyword.operator.colon.vehicle
+#          ^^^^ source.vehicle
+#              ^^ source.vehicle keyword.operator.arrow.vehicle
+#                ^^^^ source.vehicle
+#                    ^^ source.vehicle keyword.operator.arrow.vehicle
+#                      ^ source.vehicle
+#                       ^^^^ source.vehicle support.type.bool.vehicle
+>  , geTC : t1 -> t2 -> Bool
+#^^^^^^^^^ source.vehicle
+#         ^ source.vehicle keyword.operator.colon.vehicle
+#          ^^^^ source.vehicle
+#              ^^ source.vehicle keyword.operator.arrow.vehicle
+#                ^^^^ source.vehicle
+#                    ^^ source.vehicle keyword.operator.arrow.vehicle
+#                      ^ source.vehicle
+#                       ^^^^ source.vehicle support.type.bool.vehicle
+>  , gtTC : t1 -> t2 -> Bool
+#^^^^^^^^^ source.vehicle
+#         ^ source.vehicle keyword.operator.colon.vehicle
+#          ^^^^ source.vehicle
+#              ^^ source.vehicle keyword.operator.arrow.vehicle
+#                ^^^^ source.vehicle
+#                    ^^ source.vehicle keyword.operator.arrow.vehicle
+#                      ^ source.vehicle
+#                       ^^^^ source.vehicle support.type.bool.vehicle
+>  , eqTC : t1 -> t2 -> Bool
+#^^^^^^^^^ source.vehicle
+#         ^ source.vehicle keyword.operator.colon.vehicle
+#          ^^^^ source.vehicle
+#              ^^ source.vehicle keyword.operator.arrow.vehicle
+#                ^^^^ source.vehicle
+#                    ^^ source.vehicle keyword.operator.arrow.vehicle
+#                      ^ source.vehicle
+#                       ^^^^ source.vehicle support.type.bool.vehicle
+>  , neTC : t1 -> t2 -> Bool
+#^^^^^^^^^ source.vehicle
+#         ^ source.vehicle keyword.operator.colon.vehicle
+#          ^^^^ source.vehicle
+#              ^^ source.vehicle keyword.operator.arrow.vehicle
+#                ^^^^ source.vehicle
+#                    ^^ source.vehicle keyword.operator.arrow.vehicle
+#                      ^ source.vehicle
+#                       ^^^^ source.vehicle support.type.bool.vehicle
+>  }
+#^^^^ source.vehicle
+>
+>

--- a/tests/snap/record.vcl.snap
+++ b/tests/snap/record.vcl.snap
@@ -73,4 +73,25 @@
 >  }
 #^^^^ source.vehicle
 >
+>@tensor
+#^^^^^^^ source.vehicle keyword.other.declaration.tensor.vehicle
+>record Pair where
+#^^^^^^ source.vehicle keyword.other.declaration.record.vehicle
+#      ^^^^^^ source.vehicle
+#            ^^^^^ source.vehicle keyword.other.declaration.where.vehicle
+>  { a : Real
+#^^^^^^ source.vehicle
+#      ^ source.vehicle keyword.operator.colon.vehicle
+#       ^ source.vehicle
+#        ^^^^ source.vehicle support.type.rat.vehicle
+>  , b : Real
+#^^^^^^ source.vehicle
+#      ^ source.vehicle keyword.operator.colon.vehicle
+#       ^ source.vehicle
+#        ^^^^ source.vehicle support.type.rat.vehicle
+>  } supports Addition
+#^^^^ source.vehicle
+#    ^^^^^^^^ source.vehicle keyword.other.declaration.supports.vehicle
+#            ^^^^^^^^^^ source.vehicle
+>
 >

--- a/tests/snap/std.vcl.snap
+++ b/tests/snap/std.vcl.snap
@@ -79,9 +79,7 @@
 #                              ^^^^^ source.vehicle constant.language.false.vehicle
 >
 >forallIn : forallT {f : Type -> Type} . {{HasFold f}} -> {{HasMap f}} -> (A -> Bool) -> f A -> Bool
-#^ source.vehicle
-# ^^ source.vehicle keyword.operator.or.vehicle
-#   ^^^^^^ source.vehicle
+#^^^^^^^^^ source.vehicle
 #         ^ source.vehicle keyword.operator.colon.vehicle
 #          ^ source.vehicle
 #           ^^^^^^^ source.vehicle support.type.forall.vehicle
@@ -110,9 +108,7 @@
 #                                                                                              ^ source.vehicle
 #                                                                                               ^^^^ source.vehicle support.type.bool.vehicle
 >forallIn f xs = bigAnd (map f xs)
-#^ source.vehicle
-# ^^ source.vehicle keyword.operator.or.vehicle
-#   ^^^^^^^^^^^ source.vehicle
+#^^^^^^^^^^^^^^ source.vehicle
 #              ^ source.vehicle keyword.operator.define.vehicle
 #               ^^^^^^^^^ source.vehicle
 #                        ^^^ source.vehicle constant.language.map.vehicle
@@ -165,11 +161,7 @@
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.vehicle comment.line.double-dash.vehicle
 >
 >vectorToVector : forallT {n} {A} . Vector A n -> Vector A n
-#^^^^ source.vehicle
-#    ^^ source.vehicle keyword.operator.or.vehicle
-#      ^^^^^^ source.vehicle
-#            ^^ source.vehicle keyword.operator.or.vehicle
-#              ^ source.vehicle
+#^^^^^^^^^^^^^^^ source.vehicle
 #               ^ source.vehicle keyword.operator.colon.vehicle
 #                ^ source.vehicle
 #                 ^^^^^^^ source.vehicle support.type.forall.vehicle
@@ -183,18 +175,12 @@
 #                                                 ^^^^^^ source.vehicle support.type.vector.vehicle
 #                                                       ^^^^^ source.vehicle
 >vectorToVector xs = xs
-#^^^^ source.vehicle
-#    ^^ source.vehicle keyword.operator.or.vehicle
-#      ^^^^^^ source.vehicle
-#            ^^ source.vehicle keyword.operator.or.vehicle
-#              ^^^^ source.vehicle
+#^^^^^^^^^^^^^^^^^^ source.vehicle
 #                  ^ source.vehicle keyword.operator.define.vehicle
 #                   ^^^^ source.vehicle
 >
 >mapVector : forallT {n} {A} {B} . (A -> B) -> Vector A n -> Vector B n
-#^^^^^^^ source.vehicle
-#       ^^ source.vehicle keyword.operator.or.vehicle
-#         ^ source.vehicle
+#^^^^^^^^^^ source.vehicle
 #          ^ source.vehicle keyword.operator.colon.vehicle
 #           ^ source.vehicle
 #            ^^^^^^^ source.vehicle support.type.forall.vehicle
@@ -212,9 +198,7 @@
 #                                                            ^^^^^^ source.vehicle support.type.vector.vehicle
 #                                                                  ^^^^^ source.vehicle
 >mapVector {n} {A} {B} f = dfold {A} {n} {Vector B} (\{l} x xs -> f x ::v xs) []
-#^^^^^^^ source.vehicle
-#       ^^ source.vehicle keyword.operator.or.vehicle
-#         ^^^^^^^^^^^^^^^ source.vehicle
+#^^^^^^^^^^^^^^^^^^^^^^^^ source.vehicle
 #                        ^ source.vehicle keyword.operator.define.vehicle
 #                         ^ source.vehicle
 #                          ^^^^^ source.vehicle constant.language.dfold.vehicle
@@ -227,11 +211,7 @@
 #                                                                       ^^^^^^^^^ source.vehicle
 >
 >foreachVector : (Index n -> A) -> Vector A n
-#^ source.vehicle
-# ^^ source.vehicle keyword.operator.or.vehicle
-#   ^^^^^^^^ source.vehicle
-#           ^^ source.vehicle keyword.operator.or.vehicle
-#             ^ source.vehicle
+#^^^^^^^^^^^^^^ source.vehicle
 #              ^ source.vehicle keyword.operator.colon.vehicle
 #               ^^ source.vehicle
 #                 ^^^^^ source.vehicle support.type.index.vehicle
@@ -243,11 +223,7 @@
 #                                  ^^^^^^ source.vehicle support.type.vector.vehicle
 #                                        ^^^^^ source.vehicle
 >foreachVector {A} {n} f = map f (indices n)
-#^ source.vehicle
-# ^^ source.vehicle keyword.operator.or.vehicle
-#   ^^^^^^^^ source.vehicle
-#           ^^ source.vehicle keyword.operator.or.vehicle
-#             ^^^^^^^^^^^ source.vehicle
+#^^^^^^^^^^^^^^^^^^^^^^^^ source.vehicle
 #                        ^ source.vehicle keyword.operator.define.vehicle
 #                         ^ source.vehicle
 #                          ^^^ source.vehicle constant.language.map.vehicle
@@ -291,9 +267,7 @@
 >@noinline
 #^^^^^^^^^ source.vehicle keyword.other.declaration.noinline.vehicle
 >addVector : {{HasAdd A B C}} -> Vector A n -> Vector B n -> Vector C n
-#^^^^^^^ source.vehicle
-#       ^^ source.vehicle keyword.operator.or.vehicle
-#         ^ source.vehicle
+#^^^^^^^^^^ source.vehicle
 #          ^ source.vehicle keyword.operator.colon.vehicle
 #           ^^^^^^^^^^^^^^^^^^ source.vehicle
 #                             ^^ source.vehicle keyword.operator.arrow.vehicle
@@ -309,9 +283,7 @@
 #                                                            ^^^^^^ source.vehicle support.type.vector.vehicle
 #                                                                  ^^^^^ source.vehicle
 >addVector = zipWith (\x y -> x + y)
-#^^^^^^^ source.vehicle
-#       ^^ source.vehicle keyword.operator.or.vehicle
-#         ^ source.vehicle
+#^^^^^^^^^^ source.vehicle
 #          ^ source.vehicle keyword.operator.define.vehicle
 #           ^^^^^^^^^^^^^^^ source.vehicle
 #                          ^^ source.vehicle keyword.operator.arrow.vehicle
@@ -322,9 +294,7 @@
 >@noinline
 #^^^^^^^^^ source.vehicle keyword.other.declaration.noinline.vehicle
 >subVector : {{HasSub A B C}} -> Vector A n -> Vector B n -> Vector C n
-#^^^^^^^ source.vehicle
-#       ^^ source.vehicle keyword.operator.or.vehicle
-#         ^ source.vehicle
+#^^^^^^^^^^ source.vehicle
 #          ^ source.vehicle keyword.operator.colon.vehicle
 #           ^^^^^^^^^^^^^^^^^^ source.vehicle
 #                             ^^ source.vehicle keyword.operator.arrow.vehicle
@@ -340,9 +310,7 @@
 #                                                            ^^^^^^ source.vehicle support.type.vector.vehicle
 #                                                                  ^^^^^ source.vehicle
 >subVector = zipWith (\x y -> x - y)
-#^^^^^^^ source.vehicle
-#       ^^ source.vehicle keyword.operator.or.vehicle
-#         ^ source.vehicle
+#^^^^^^^^^^ source.vehicle
 #          ^ source.vehicle keyword.operator.define.vehicle
 #           ^^^^^^^^^^^^^^^ source.vehicle
 #                          ^^ source.vehicle keyword.operator.arrow.vehicle
@@ -353,9 +321,7 @@
 >@noinline
 #^^^^^^^^^ source.vehicle keyword.other.declaration.noinline.vehicle
 >equalsVector : {{HasEq A B}} -> Vector A n -> Vector B n -> Bool
-#^^^^^^^^^^ source.vehicle
-#          ^^ source.vehicle keyword.operator.or.vehicle
-#            ^ source.vehicle
+#^^^^^^^^^^^^^ source.vehicle
 #             ^ source.vehicle keyword.operator.colon.vehicle
 #              ^^^^^^^^^^^^^^^ source.vehicle
 #                             ^^ source.vehicle keyword.operator.arrow.vehicle
@@ -370,9 +336,7 @@
 #                                                           ^ source.vehicle
 #                                                            ^^^^ source.vehicle support.type.bool.vehicle
 >equalsVector xs ys = bigAnd (zipWith (\x y -> x == y) xs ys)
-#^^^^^^^^^^ source.vehicle
-#          ^^ source.vehicle keyword.operator.or.vehicle
-#            ^^^^^^^ source.vehicle
+#^^^^^^^^^^^^^^^^^^^ source.vehicle
 #                   ^ source.vehicle keyword.operator.define.vehicle
 #                    ^^^^^^^^^^^^^^^^^^^^^^^ source.vehicle
 #                                           ^^ source.vehicle keyword.operator.arrow.vehicle
@@ -381,9 +345,7 @@
 #                                                  ^^^^^^^^^^^ source.vehicle
 >
 >notEqualsVector : {{HasNotEq A B}} -> Vector A n -> Vector B n -> Bool
-#^^^^^^^^^^^^^ source.vehicle
-#             ^^ source.vehicle keyword.operator.or.vehicle
-#               ^ source.vehicle
+#^^^^^^^^^^^^^^^^ source.vehicle
 #                ^ source.vehicle keyword.operator.colon.vehicle
 #                 ^^^^^^^^^^^^^^^^^^ source.vehicle
 #                                   ^^ source.vehicle keyword.operator.arrow.vehicle
@@ -398,9 +360,7 @@
 #                                                                 ^ source.vehicle
 #                                                                  ^^^^ source.vehicle support.type.bool.vehicle
 >notEqualsVector xs ys = bigOr (zipWith (\x y -> x != y) xs ys)
-#^^^^^^^^^^^^^ source.vehicle
-#             ^^ source.vehicle keyword.operator.or.vehicle
-#               ^^^^^^^ source.vehicle
+#^^^^^^^^^^^^^^^^^^^^^^ source.vehicle
 #                      ^ source.vehicle keyword.operator.define.vehicle
 #                       ^^^^^^^^^^^^^^^^^^^^^^ source.vehicle
 #                                             ^^ source.vehicle keyword.operator.arrow.vehicle
@@ -441,9 +401,7 @@
 #                                  ^^^^^^ source.vehicle
 >
 >forallIndex : (Index n -> Bool) -> Bool
-#^ source.vehicle
-# ^^ source.vehicle keyword.operator.or.vehicle
-#   ^^^^^^^^^ source.vehicle
+#^^^^^^^^^^^^ source.vehicle
 #            ^ source.vehicle keyword.operator.colon.vehicle
 #             ^^ source.vehicle
 #               ^^^^^ source.vehicle support.type.index.vehicle
@@ -456,9 +414,7 @@
 #                                  ^ source.vehicle
 #                                   ^^^^ source.vehicle support.type.bool.vehicle
 >forallIndex f = bigAnd (foreach i . f i)
-#^ source.vehicle
-# ^^ source.vehicle keyword.operator.or.vehicle
-#   ^^^^^^^^^^^ source.vehicle
+#^^^^^^^^^^^^^^ source.vehicle
 #              ^ source.vehicle keyword.operator.define.vehicle
 #               ^^^^^^^^^ source.vehicle
 #                        ^^^^^^^ source.vehicle keyword.control.foreach.vehicle
@@ -515,9 +471,7 @@
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.vehicle comment.line.double-dash.vehicle
 >
 >vectorToList : forallT {n} {A} . Vector A n -> List A
-#^^^^ source.vehicle
-#    ^^ source.vehicle keyword.operator.or.vehicle
-#      ^^^^^^^ source.vehicle
+#^^^^^^^^^^^^^ source.vehicle
 #             ^ source.vehicle keyword.operator.colon.vehicle
 #              ^ source.vehicle
 #               ^^^^^^^ source.vehicle support.type.forall.vehicle
@@ -531,9 +485,7 @@
 #                                               ^^^^ source.vehicle support.type.list.vehicle
 #                                                   ^^^ source.vehicle
 >vectorToList = fold (\x xs -> x :: xs) nil
-#^^^^ source.vehicle
-#    ^^ source.vehicle keyword.operator.or.vehicle
-#      ^^^^^^^ source.vehicle
+#^^^^^^^^^^^^^ source.vehicle
 #             ^ source.vehicle keyword.operator.define.vehicle
 #              ^ source.vehicle
 #               ^^^^ source.vehicle constant.language.fold.vehicle

--- a/tests/snap/test_addition.vcl
+++ b/tests/snap/test_addition.vcl
@@ -1,2 +1,2 @@
-addition : Rat
+addition : Real
 addition = 6 + 2

--- a/tests/snap/test_addition.vcl.snap
+++ b/tests/snap/test_addition.vcl.snap
@@ -1,8 +1,8 @@
->addition : Rat
+>addition : Real
 #^^^^^^^^^ source.vehicle
 #         ^ source.vehicle keyword.operator.colon.vehicle
 #          ^ source.vehicle
-#           ^^^ source.vehicle support.type.rat.vehicle
+#           ^^^^ source.vehicle support.type.rat.vehicle
 >addition = 6 + 2
 #^^^^^^^^^ source.vehicle
 #         ^ source.vehicle keyword.operator.define.vehicle

--- a/tests/snap/test_at.vcl
+++ b/tests/snap/test_at.vcl
@@ -1,5 +1,5 @@
-ten : Tensor Rat [3]
+ten : Tensor Real [3]
 ten = [2, 3, 5]
 
-at : Rat
+at : Real
 at = ten ! 1

--- a/tests/snap/test_at.vcl.snap
+++ b/tests/snap/test_at.vcl.snap
@@ -1,13 +1,13 @@
->ten : Tensor Rat [3]
+>ten : Tensor Real [3]
 #^^^^ source.vehicle
 #    ^ source.vehicle keyword.operator.colon.vehicle
 #     ^ source.vehicle
 #      ^^^^^^ source.vehicle support.type.tensor.vehicle
 #            ^ source.vehicle
-#             ^^^ source.vehicle support.type.rat.vehicle
-#                ^^ source.vehicle
-#                  ^ source.vehicle constant.numeric.integral.decimal.vehicle
-#                   ^^ source.vehicle
+#             ^^^^ source.vehicle support.type.rat.vehicle
+#                 ^^ source.vehicle
+#                   ^ source.vehicle constant.numeric.integral.decimal.vehicle
+#                    ^^ source.vehicle
 >ten = [2, 3, 5]
 #^^^^ source.vehicle
 #    ^ source.vehicle keyword.operator.define.vehicle
@@ -19,11 +19,11 @@
 #             ^ source.vehicle constant.numeric.integral.decimal.vehicle
 #              ^^ source.vehicle
 >
->at : Rat
+>at : Real
 #^^^ source.vehicle
 #   ^ source.vehicle keyword.operator.colon.vehicle
 #    ^ source.vehicle
-#     ^^^ source.vehicle support.type.rat.vehicle
+#     ^^^^ source.vehicle support.type.rat.vehicle
 >at = ten ! 1
 #^^^ source.vehicle
 #   ^ source.vehicle keyword.operator.define.vehicle

--- a/tests/snap/test_boundaries.vcl
+++ b/tests/snap/test_boundaries.vcl
@@ -1,0 +1,6 @@
+strands: Real
+-- ^^^ - source.vehicle keyword.operator.and.vehicle
+
+chlorine: Real
+-- ^^ - source.vehicle keyword.operator.or.vehicle
+

--- a/tests/snap/test_boundaries.vcl.snap
+++ b/tests/snap/test_boundaries.vcl.snap
@@ -1,0 +1,19 @@
+>strands: Real
+#^^^^^^^ source.vehicle
+#       ^ source.vehicle keyword.operator.colon.vehicle
+#        ^ source.vehicle
+#         ^^^^ source.vehicle support.type.rat.vehicle
+>-- ^^^ - source.vehicle keyword.operator.and.vehicle
+#^^ source.vehicle comment.line.double-dash.vehicle punctuation.definition.comment.vehicle
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.vehicle comment.line.double-dash.vehicle
+>
+>chlorine: Real
+#^^^^^^^^ source.vehicle
+#        ^ source.vehicle keyword.operator.colon.vehicle
+#         ^ source.vehicle
+#          ^^^^ source.vehicle support.type.rat.vehicle
+>-- ^^ - source.vehicle keyword.operator.or.vehicle
+#^^ source.vehicle comment.line.double-dash.vehicle punctuation.definition.comment.vehicle
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.vehicle comment.line.double-dash.vehicle
+>
+>

--- a/tests/snap/test_bounded.vcl
+++ b/tests/snap/test_bounded.vcl
@@ -1,5 +1,5 @@
 @network
-f : Tensor Rat [1] -> Tensor Rat [1]
+f : Tensor Real [1] -> Tensor Real [1]
 
 @property
 bounded : Bool

--- a/tests/snap/test_bounded.vcl.snap
+++ b/tests/snap/test_bounded.vcl.snap
@@ -1,23 +1,23 @@
 >@network
 #^^^^^^^^ source.vehicle keyword.other.declaration.network.vehicle
->f : Tensor Rat [1] -> Tensor Rat [1]
+>f : Tensor Real [1] -> Tensor Real [1]
 #^^ source.vehicle
 #  ^ source.vehicle keyword.operator.colon.vehicle
 #   ^ source.vehicle
 #    ^^^^^^ source.vehicle support.type.tensor.vehicle
 #          ^ source.vehicle
-#           ^^^ source.vehicle support.type.rat.vehicle
-#              ^^ source.vehicle
-#                ^ source.vehicle constant.numeric.integral.decimal.vehicle
-#                 ^^ source.vehicle
-#                   ^^ source.vehicle keyword.operator.arrow.vehicle
-#                     ^ source.vehicle
-#                      ^^^^^^ source.vehicle support.type.tensor.vehicle
-#                            ^ source.vehicle
-#                             ^^^ source.vehicle support.type.rat.vehicle
-#                                ^^ source.vehicle
-#                                  ^ source.vehicle constant.numeric.integral.decimal.vehicle
-#                                   ^^ source.vehicle
+#           ^^^^ source.vehicle support.type.rat.vehicle
+#               ^^ source.vehicle
+#                 ^ source.vehicle constant.numeric.integral.decimal.vehicle
+#                  ^^ source.vehicle
+#                    ^^ source.vehicle keyword.operator.arrow.vehicle
+#                      ^ source.vehicle
+#                       ^^^^^^ source.vehicle support.type.tensor.vehicle
+#                             ^ source.vehicle
+#                              ^^^^ source.vehicle support.type.rat.vehicle
+#                                  ^^ source.vehicle
+#                                    ^ source.vehicle constant.numeric.integral.decimal.vehicle
+#                                     ^^ source.vehicle
 >
 >@property
 #^^^^^^^^^ source.vehicle keyword.other.declaration.property.vehicle

--- a/tests/snap/test_division.vcl
+++ b/tests/snap/test_division.vcl
@@ -1,2 +1,2 @@
-division : Rat
+division : Real
 division = 6 / 2

--- a/tests/snap/test_division.vcl.snap
+++ b/tests/snap/test_division.vcl.snap
@@ -1,8 +1,8 @@
->division : Rat
+>division : Real
 #^^^^^^^^^ source.vehicle
 #         ^ source.vehicle keyword.operator.colon.vehicle
 #          ^ source.vehicle
-#           ^^^ source.vehicle support.type.rat.vehicle
+#           ^^^^ source.vehicle support.type.rat.vehicle
 >division = 6 / 2
 #^^^^^^^^^ source.vehicle
 #         ^ source.vehicle keyword.operator.define.vehicle

--- a/tests/snap/test_indicator.vcl.snap
+++ b/tests/snap/test_indicator.vcl.snap
@@ -1,14 +1,10 @@
 >indicator : Bool
-#^^^^^^^ source.vehicle
-#       ^^ source.vehicle keyword.operator.or.vehicle
-#         ^ source.vehicle
+#^^^^^^^^^^ source.vehicle
 #          ^ source.vehicle keyword.operator.colon.vehicle
 #           ^ source.vehicle
 #            ^^^^ source.vehicle support.type.bool.vehicle
 >indicator = 1 != 1
-#^^^^^^^ source.vehicle
-#       ^^ source.vehicle keyword.operator.or.vehicle
-#         ^ source.vehicle
+#^^^^^^^^^^ source.vehicle
 #          ^ source.vehicle keyword.operator.define.vehicle
 #           ^ source.vehicle
 #            ^ source.vehicle constant.numeric.integral.decimal.vehicle

--- a/tests/snap/test_multiplication.vcl
+++ b/tests/snap/test_multiplication.vcl
@@ -1,2 +1,2 @@
-multiplication : Rat
+multiplication : Real
 multiplication = 6 * 2

--- a/tests/snap/test_multiplication.vcl.snap
+++ b/tests/snap/test_multiplication.vcl.snap
@@ -1,8 +1,8 @@
->multiplication : Rat
+>multiplication : Real
 #^^^^^^^^^^^^^^^ source.vehicle
 #               ^ source.vehicle keyword.operator.colon.vehicle
 #                ^ source.vehicle
-#                 ^^^ source.vehicle support.type.rat.vehicle
+#                 ^^^^ source.vehicle support.type.rat.vehicle
 >multiplication = 6 * 2
 #^^^^^^^^^^^^^^^ source.vehicle
 #               ^ source.vehicle keyword.operator.define.vehicle

--- a/tests/snap/test_network.vcl
+++ b/tests/snap/test_network.vcl
@@ -1,5 +1,5 @@
 @network
-net : Tensor Rat [1] -> Tensor Rat [1]
+net : Tensor Real [1] -> Tensor Real [1]
 
 @property
 net_prop : Bool

--- a/tests/snap/test_network.vcl.snap
+++ b/tests/snap/test_network.vcl.snap
@@ -1,23 +1,23 @@
 >@network
 #^^^^^^^^ source.vehicle keyword.other.declaration.network.vehicle
->net : Tensor Rat [1] -> Tensor Rat [1]
+>net : Tensor Real [1] -> Tensor Real [1]
 #^^^^ source.vehicle
 #    ^ source.vehicle keyword.operator.colon.vehicle
 #     ^ source.vehicle
 #      ^^^^^^ source.vehicle support.type.tensor.vehicle
 #            ^ source.vehicle
-#             ^^^ source.vehicle support.type.rat.vehicle
-#                ^^ source.vehicle
-#                  ^ source.vehicle constant.numeric.integral.decimal.vehicle
-#                   ^^ source.vehicle
-#                     ^^ source.vehicle keyword.operator.arrow.vehicle
-#                       ^ source.vehicle
-#                        ^^^^^^ source.vehicle support.type.tensor.vehicle
-#                              ^ source.vehicle
-#                               ^^^ source.vehicle support.type.rat.vehicle
-#                                  ^^ source.vehicle
-#                                    ^ source.vehicle constant.numeric.integral.decimal.vehicle
-#                                     ^^ source.vehicle
+#             ^^^^ source.vehicle support.type.rat.vehicle
+#                 ^^ source.vehicle
+#                   ^ source.vehicle constant.numeric.integral.decimal.vehicle
+#                    ^^ source.vehicle
+#                      ^^ source.vehicle keyword.operator.arrow.vehicle
+#                        ^ source.vehicle
+#                         ^^^^^^ source.vehicle support.type.tensor.vehicle
+#                               ^ source.vehicle
+#                                ^^^^ source.vehicle support.type.rat.vehicle
+#                                    ^^ source.vehicle
+#                                      ^ source.vehicle constant.numeric.integral.decimal.vehicle
+#                                       ^^ source.vehicle
 >
 >@property
 #^^^^^^^^^ source.vehicle keyword.other.declaration.property.vehicle

--- a/tests/snap/test_quantifier_all.vcl
+++ b/tests/snap/test_quantifier_all.vcl
@@ -1,2 +1,2 @@
 quantifierForall : Bool
-quantifierForall = forall (x : Rat) . x >= 0
+quantifierForall = forall (x : Real) . x >= 0

--- a/tests/snap/test_quantifier_all.vcl.snap
+++ b/tests/snap/test_quantifier_all.vcl.snap
@@ -5,7 +5,7 @@
 #                 ^ source.vehicle keyword.operator.colon.vehicle
 #                  ^ source.vehicle
 #                   ^^^^ source.vehicle support.type.bool.vehicle
->quantifierForall = forall (x : Rat) . x >= 0
+>quantifierForall = forall (x : Real) . x >= 0
 #^^^^^^^^^^^ source.vehicle
 #           ^^ source.vehicle keyword.operator.or.vehicle
 #             ^^^^ source.vehicle
@@ -15,11 +15,11 @@
 #                         ^^^^ source.vehicle
 #                             ^ source.vehicle keyword.operator.colon.vehicle
 #                              ^ source.vehicle
-#                               ^^^ source.vehicle support.type.rat.vehicle
-#                                  ^^ source.vehicle
-#                                    ^ source.vehicle keyword.operator.dot.vehicle
-#                                     ^^^ source.vehicle
-#                                        ^^ source.vehicle keyword.operator.gte.vehicle
-#                                          ^ source.vehicle
-#                                           ^ source.vehicle constant.numeric.integral.decimal.vehicle
+#                               ^^^^ source.vehicle support.type.rat.vehicle
+#                                   ^^ source.vehicle
+#                                     ^ source.vehicle keyword.operator.dot.vehicle
+#                                      ^^^ source.vehicle
+#                                         ^^ source.vehicle keyword.operator.gte.vehicle
+#                                           ^ source.vehicle
+#                                            ^ source.vehicle constant.numeric.integral.decimal.vehicle
 >

--- a/tests/snap/test_quantifier_all.vcl.snap
+++ b/tests/snap/test_quantifier_all.vcl.snap
@@ -1,14 +1,10 @@
 >quantifierForall : Bool
-#^^^^^^^^^^^ source.vehicle
-#           ^^ source.vehicle keyword.operator.or.vehicle
-#             ^^^^ source.vehicle
+#^^^^^^^^^^^^^^^^^ source.vehicle
 #                 ^ source.vehicle keyword.operator.colon.vehicle
 #                  ^ source.vehicle
 #                   ^^^^ source.vehicle support.type.bool.vehicle
 >quantifierForall = forall (x : Real) . x >= 0
-#^^^^^^^^^^^ source.vehicle
-#           ^^ source.vehicle keyword.operator.or.vehicle
-#             ^^^^ source.vehicle
+#^^^^^^^^^^^^^^^^^ source.vehicle
 #                 ^ source.vehicle keyword.operator.define.vehicle
 #                  ^ source.vehicle
 #                   ^^^^^^ source.vehicle keyword.control.forall.vehicle

--- a/tests/snap/test_quantifier_any.vcl
+++ b/tests/snap/test_quantifier_any.vcl
@@ -1,2 +1,2 @@
 quantifierExists : Bool
-quantifierExists = exists (x : Rat) . x >= 0
+quantifierExists = exists (x : Real) . x >= 0

--- a/tests/snap/test_quantifier_any.vcl.snap
+++ b/tests/snap/test_quantifier_any.vcl.snap
@@ -3,7 +3,7 @@
 #                 ^ source.vehicle keyword.operator.colon.vehicle
 #                  ^ source.vehicle
 #                   ^^^^ source.vehicle support.type.bool.vehicle
->quantifierExists = exists (x : Rat) . x >= 0
+>quantifierExists = exists (x : Real) . x >= 0
 #^^^^^^^^^^^^^^^^^ source.vehicle
 #                 ^ source.vehicle keyword.operator.define.vehicle
 #                  ^ source.vehicle
@@ -11,11 +11,11 @@
 #                         ^^^^ source.vehicle
 #                             ^ source.vehicle keyword.operator.colon.vehicle
 #                              ^ source.vehicle
-#                               ^^^ source.vehicle support.type.rat.vehicle
-#                                  ^^ source.vehicle
-#                                    ^ source.vehicle keyword.operator.dot.vehicle
-#                                     ^^^ source.vehicle
-#                                        ^^ source.vehicle keyword.operator.gte.vehicle
-#                                          ^ source.vehicle
-#                                           ^ source.vehicle constant.numeric.integral.decimal.vehicle
+#                               ^^^^ source.vehicle support.type.rat.vehicle
+#                                   ^^ source.vehicle
+#                                     ^ source.vehicle keyword.operator.dot.vehicle
+#                                      ^^^ source.vehicle
+#                                         ^^ source.vehicle keyword.operator.gte.vehicle
+#                                           ^ source.vehicle
+#                                            ^ source.vehicle constant.numeric.integral.decimal.vehicle
 >

--- a/tests/snap/test_subtraction.vcl
+++ b/tests/snap/test_subtraction.vcl
@@ -1,2 +1,2 @@
-subtraction : Rat
+subtraction : Real
 subtraction = 6 - 2

--- a/tests/snap/test_subtraction.vcl.snap
+++ b/tests/snap/test_subtraction.vcl.snap
@@ -1,8 +1,8 @@
->subtraction : Rat
+>subtraction : Real
 #^^^^^^^^^^^^ source.vehicle
 #            ^ source.vehicle keyword.operator.colon.vehicle
 #             ^ source.vehicle
-#              ^^^ source.vehicle support.type.rat.vehicle
+#              ^^^^ source.vehicle support.type.rat.vehicle
 >subtraction = 6 - 2
 #^^^^^^^^^^^^ source.vehicle
 #            ^ source.vehicle keyword.operator.define.vehicle

--- a/tests/snap/test_tensor.vcl
+++ b/tests/snap/test_tensor.vcl
@@ -1,2 +1,2 @@
-tensor : Tensor Rat [4]
+tensor : Tensor Real [4]
 tensor = [5, 2, 16, 7]

--- a/tests/snap/test_tensor.vcl.snap
+++ b/tests/snap/test_tensor.vcl.snap
@@ -1,7 +1,5 @@
 >tensor : Tensor Real [4]
-#^^^^ source.vehicle
-#    ^^ source.vehicle keyword.operator.or.vehicle
-#      ^ source.vehicle
+#^^^^^^^ source.vehicle
 #       ^ source.vehicle keyword.operator.colon.vehicle
 #        ^ source.vehicle
 #         ^^^^^^ source.vehicle support.type.tensor.vehicle
@@ -11,9 +9,7 @@
 #                      ^ source.vehicle constant.numeric.integral.decimal.vehicle
 #                       ^^ source.vehicle
 >tensor = [5, 2, 16, 7]
-#^^^^ source.vehicle
-#    ^^ source.vehicle keyword.operator.or.vehicle
-#      ^ source.vehicle
+#^^^^^^^ source.vehicle
 #       ^ source.vehicle keyword.operator.define.vehicle
 #        ^^ source.vehicle
 #          ^ source.vehicle constant.numeric.integral.decimal.vehicle

--- a/tests/snap/test_tensor.vcl.snap
+++ b/tests/snap/test_tensor.vcl.snap
@@ -1,4 +1,4 @@
->tensor : Tensor Rat [4]
+>tensor : Tensor Real [4]
 #^^^^ source.vehicle
 #    ^^ source.vehicle keyword.operator.or.vehicle
 #      ^ source.vehicle
@@ -6,10 +6,10 @@
 #        ^ source.vehicle
 #         ^^^^^^ source.vehicle support.type.tensor.vehicle
 #               ^ source.vehicle
-#                ^^^ source.vehicle support.type.rat.vehicle
-#                   ^^ source.vehicle
-#                     ^ source.vehicle constant.numeric.integral.decimal.vehicle
-#                      ^^ source.vehicle
+#                ^^^^ source.vehicle support.type.rat.vehicle
+#                    ^^ source.vehicle
+#                      ^ source.vehicle constant.numeric.integral.decimal.vehicle
+#                       ^^ source.vehicle
 >tensor = [5, 2, 16, 7]
 #^^^^ source.vehicle
 #    ^^ source.vehicle keyword.operator.or.vehicle

--- a/tests/snap/unparseableRat.vcl
+++ b/tests/snap/unparseableRat.vcl
@@ -1,2 +1,2 @@
 @parameter
-r : Rat
+r : Real

--- a/tests/snap/unparseableRat.vcl.snap
+++ b/tests/snap/unparseableRat.vcl.snap
@@ -1,8 +1,8 @@
 >@parameter
 #^^^^^^^^^^ source.vehicle keyword.other.declaration.parameter.vehicle
->r : Rat
+>r : Real
 #^^ source.vehicle
 #  ^ source.vehicle keyword.operator.colon.vehicle
 #   ^ source.vehicle
-#    ^^^ source.vehicle support.type.rat.vehicle
+#    ^^^^ source.vehicle support.type.rat.vehicle
 >

--- a/tests/snap/unsupportedFormat.vcl
+++ b/tests/snap/unsupportedFormat.vcl
@@ -1,3 +1,3 @@
 -- Test provides a reference to the dataset in an unsupported format.
 @dataset
-trainingDataset : List Rat
+trainingDataset : List Real

--- a/tests/snap/unsupportedFormat.vcl.snap
+++ b/tests/snap/unsupportedFormat.vcl.snap
@@ -3,11 +3,11 @@
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.vehicle comment.line.double-dash.vehicle
 >@dataset
 #^^^^^^^^ source.vehicle keyword.other.declaration.dataset.vehicle
->trainingDataset : List Rat
+>trainingDataset : List Real
 #^^^^^^^^^^^^^^^^ source.vehicle
 #                ^ source.vehicle keyword.operator.colon.vehicle
 #                 ^ source.vehicle
 #                  ^^^^ source.vehicle support.type.list.vehicle
 #                      ^ source.vehicle
-#                       ^^^ source.vehicle support.type.rat.vehicle
+#                       ^^^^ source.vehicle support.type.rat.vehicle
 >

--- a/tests/snap/variableDimensions.vcl
+++ b/tests/snap/variableDimensions.vcl
@@ -1,5 +1,5 @@
 @network
-f : Tensor Rat [1] -> Tensor Rat [1]
+f : Tensor Real [1] -> Tensor Real [1]
 
 @dataset
 trainingDataset : Tensor Nat [if f [0] ! 0 > 0 then 2 else 3 ]

--- a/tests/snap/variableDimensions.vcl.snap
+++ b/tests/snap/variableDimensions.vcl.snap
@@ -1,23 +1,23 @@
 >@network
 #^^^^^^^^ source.vehicle keyword.other.declaration.network.vehicle
->f : Tensor Rat [1] -> Tensor Rat [1]
+>f : Tensor Real [1] -> Tensor Real [1]
 #^^ source.vehicle
 #  ^ source.vehicle keyword.operator.colon.vehicle
 #   ^ source.vehicle
 #    ^^^^^^ source.vehicle support.type.tensor.vehicle
 #          ^ source.vehicle
-#           ^^^ source.vehicle support.type.rat.vehicle
-#              ^^ source.vehicle
-#                ^ source.vehicle constant.numeric.integral.decimal.vehicle
-#                 ^^ source.vehicle
-#                   ^^ source.vehicle keyword.operator.arrow.vehicle
-#                     ^ source.vehicle
-#                      ^^^^^^ source.vehicle support.type.tensor.vehicle
-#                            ^ source.vehicle
-#                             ^^^ source.vehicle support.type.rat.vehicle
-#                                ^^ source.vehicle
-#                                  ^ source.vehicle constant.numeric.integral.decimal.vehicle
-#                                   ^^ source.vehicle
+#           ^^^^ source.vehicle support.type.rat.vehicle
+#               ^^ source.vehicle
+#                 ^ source.vehicle constant.numeric.integral.decimal.vehicle
+#                  ^^ source.vehicle
+#                    ^^ source.vehicle keyword.operator.arrow.vehicle
+#                      ^ source.vehicle
+#                       ^^^^^^ source.vehicle support.type.tensor.vehicle
+#                             ^ source.vehicle
+#                              ^^^^ source.vehicle support.type.rat.vehicle
+#                                  ^^ source.vehicle
+#                                    ^ source.vehicle constant.numeric.integral.decimal.vehicle
+#                                     ^^ source.vehicle
 >
 >@dataset
 #^^^^^^^^ source.vehicle keyword.other.declaration.dataset.vehicle

--- a/tests/snap/windController.vcl
+++ b/tests/snap/windController.vcl
@@ -1,7 +1,7 @@
 --------------------------------------------------------------------------------
 -- Inputs and outputs
 
-type InputVector = Tensor Rat [2]
+type InputVector = Tensor Real [2]
 
 currentSensor  = 0
 previousSensor = 1
@@ -10,7 +10,7 @@ previousSensor = 1
 -- Network
 
 @network
-controller : InputVector -> Tensor Rat [1]
+controller : InputVector -> Tensor Real [1]
 
 --------------------------------------------------------------------------------
 -- Safety property

--- a/tests/snap/windController.vcl.snap
+++ b/tests/snap/windController.vcl.snap
@@ -5,7 +5,7 @@
 #^^ source.vehicle comment.line.double-dash.vehicle punctuation.definition.comment.vehicle
 #  ^^^^^^^^^^^^^^^^^^^ source.vehicle comment.line.double-dash.vehicle
 >
->type InputVector = Tensor Rat [2]
+>type InputVector = Tensor Real [2]
 #^^^^ source.vehicle keyword.other.declaration.type.vehicle
 #    ^^^^^^^^^^ source.vehicle
 #              ^^ source.vehicle keyword.operator.or.vehicle
@@ -14,10 +14,10 @@
 #                  ^ source.vehicle
 #                   ^^^^^^ source.vehicle support.type.tensor.vehicle
 #                         ^ source.vehicle
-#                          ^^^ source.vehicle support.type.rat.vehicle
-#                             ^^ source.vehicle
-#                               ^ source.vehicle constant.numeric.integral.decimal.vehicle
-#                                ^^ source.vehicle
+#                          ^^^^ source.vehicle support.type.rat.vehicle
+#                              ^^ source.vehicle
+#                                ^ source.vehicle constant.numeric.integral.decimal.vehicle
+#                                 ^^ source.vehicle
 >
 >currentSensor  = 0
 #^^^^^^^^^^^ source.vehicle
@@ -43,7 +43,7 @@
 >
 >@network
 #^^^^^^^^ source.vehicle keyword.other.declaration.network.vehicle
->controller : InputVector -> Tensor Rat [1]
+>controller : InputVector -> Tensor Real [1]
 #^^^^^^^^^^^ source.vehicle
 #           ^ source.vehicle keyword.operator.colon.vehicle
 #            ^^^^^^^^^^ source.vehicle
@@ -53,10 +53,10 @@
 #                           ^ source.vehicle
 #                            ^^^^^^ source.vehicle support.type.tensor.vehicle
 #                                  ^ source.vehicle
-#                                   ^^^ source.vehicle support.type.rat.vehicle
-#                                      ^^ source.vehicle
-#                                        ^ source.vehicle constant.numeric.integral.decimal.vehicle
-#                                         ^^ source.vehicle
+#                                   ^^^^ source.vehicle support.type.rat.vehicle
+#                                       ^^ source.vehicle
+#                                         ^ source.vehicle constant.numeric.integral.decimal.vehicle
+#                                          ^^ source.vehicle
 >
 >--------------------------------------------------------------------------------
 #^^ source.vehicle comment.line.double-dash.vehicle punctuation.definition.comment.vehicle

--- a/tests/snap/windController.vcl.snap
+++ b/tests/snap/windController.vcl.snap
@@ -7,9 +7,7 @@
 >
 >type InputVector = Tensor Real [2]
 #^^^^ source.vehicle keyword.other.declaration.type.vehicle
-#    ^^^^^^^^^^ source.vehicle
-#              ^^ source.vehicle keyword.operator.or.vehicle
-#                ^ source.vehicle
+#    ^^^^^^^^^^^^^ source.vehicle
 #                 ^ source.vehicle keyword.operator.define.vehicle
 #                  ^ source.vehicle
 #                   ^^^^^^ source.vehicle support.type.tensor.vehicle
@@ -20,16 +18,12 @@
 #                                 ^^ source.vehicle
 >
 >currentSensor  = 0
-#^^^^^^^^^^^ source.vehicle
-#           ^^ source.vehicle keyword.operator.or.vehicle
-#             ^^ source.vehicle
+#^^^^^^^^^^^^^^^ source.vehicle
 #               ^ source.vehicle keyword.operator.define.vehicle
 #                ^ source.vehicle
 #                 ^ source.vehicle constant.numeric.integral.decimal.vehicle
 >previousSensor = 1
-#^^^^^^^^^^^^ source.vehicle
-#            ^^ source.vehicle keyword.operator.or.vehicle
-#              ^ source.vehicle
+#^^^^^^^^^^^^^^^ source.vehicle
 #               ^ source.vehicle keyword.operator.define.vehicle
 #                ^ source.vehicle
 #                 ^ source.vehicle constant.numeric.integral.decimal.vehicle
@@ -46,9 +40,7 @@
 >controller : InputVector -> Tensor Real [1]
 #^^^^^^^^^^^ source.vehicle
 #           ^ source.vehicle keyword.operator.colon.vehicle
-#            ^^^^^^^^^^ source.vehicle
-#                      ^^ source.vehicle keyword.operator.or.vehicle
-#                        ^ source.vehicle
+#            ^^^^^^^^^^^^^ source.vehicle
 #                         ^^ source.vehicle keyword.operator.arrow.vehicle
 #                           ^ source.vehicle
 #                            ^^^^^^ source.vehicle support.type.tensor.vehicle
@@ -68,9 +60,7 @@
 >safeInput : InputVector -> Bool
 #^^^^^^^^^^ source.vehicle
 #          ^ source.vehicle keyword.operator.colon.vehicle
-#           ^^^^^^^^^^ source.vehicle
-#                     ^^ source.vehicle keyword.operator.or.vehicle
-#                       ^ source.vehicle
+#           ^^^^^^^^^^^^^ source.vehicle
 #                        ^^ source.vehicle keyword.operator.arrow.vehicle
 #                          ^ source.vehicle
 #                           ^^^^ source.vehicle support.type.bool.vehicle
@@ -96,9 +86,7 @@
 >safeOutput : InputVector -> Bool
 #^^^^^^^^^^^ source.vehicle
 #           ^ source.vehicle keyword.operator.colon.vehicle
-#            ^^^^^^^^^^ source.vehicle
-#                      ^^ source.vehicle keyword.operator.or.vehicle
-#                        ^ source.vehicle
+#            ^^^^^^^^^^^^^ source.vehicle
 #                         ^^ source.vehicle keyword.operator.arrow.vehicle
 #                           ^ source.vehicle
 #                            ^^^^ source.vehicle support.type.bool.vehicle


### PR DESCRIPTION
Before:
<img width="514" height="106" alt="before" src="https://github.com/user-attachments/assets/dc46f195-b987-4fe5-a672-1562137b139b" />

After:
<img width="514" height="106" alt="after" src="https://github.com/user-attachments/assets/ba672218-7076-4163-aa88-e00df1322f78" />

I also added a test for this. While doing so, I noticed the other tests aren't passing because when `Rat` was changed to `Real`, the tests were not updated at the same time, so I fixed the tests too (the first commit on this PR).